### PR TITLE
✨ feat: Tabs 컴포넌트 및 스토리북 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^3.3.4",
         "@mui/material": "^5.15.5",
+        "@radix-ui/react-tabs": "^1.0.4",
         "@tanstack/react-query": "^5.17.12",
         "axios": "^1.6.5",
         "clsx": "^2.1.0",
@@ -3977,7 +3978,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
       "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
@@ -4010,7 +4010,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
       "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.1",
@@ -4037,7 +4036,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
       "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -4055,7 +4053,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
       "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -4073,7 +4070,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
       "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -4163,7 +4159,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
       "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-layout-effect": "1.0.1"
@@ -4235,11 +4230,34 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
       "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-slot": "1.0.2"
@@ -4263,7 +4281,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
       "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "1.0.1",
@@ -4363,7 +4380,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
       "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.1"
@@ -4374,6 +4390,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+      "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -4468,7 +4514,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
       "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -4486,7 +4531,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
       "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "1.0.1"
@@ -4524,7 +4568,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
       "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -6588,7 +6631,7 @@
       "version": "18.2.18",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
       "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^3.3.4",
     "@mui/material": "^5.15.5",
+    "@radix-ui/react-tabs": "^1.0.4",
     "@tanstack/react-query": "^5.17.12",
     "axios": "^1.6.5",
     "clsx": "^2.1.0",

--- a/src/components/Tabs/index.stories.tsx
+++ b/src/components/Tabs/index.stories.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { css } from '@emotion/react';
+import Tabs from './';
+
+const meta = {
+  title: 'Components/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  render: (args) => (
+    <div
+      css={css`
+        padding: 1.25rem;
+        background-color: #94d1f5;
+      `}
+    >
+      <Tabs {...args} />
+    </div>
+  ),
+  args: {
+    defaultValue: 'tab2',
+    variant: 'primary',
+    tabItems: [
+      {
+        key: 'tab1',
+        label: 'One',
+        content: 'Tab one content',
+      },
+      {
+        key: 'tab2',
+        label: 'Two',
+        content: 'Tab two content',
+      },
+      {
+        key: 'tab3',
+        label: 'Three',
+        content: 'Tab three content',
+      },
+    ],
+  },
+};
+
+const 보관함Components = {
+  Content: ({ children }: React.PropsWithChildren) => {
+    return (
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+          margin-top: 1rem;
+        `}
+      >
+        {children}
+      </div>
+    );
+  },
+};
+
+export const 보관함: Story = {
+  render: (args) => (
+    <div
+      css={css`
+        padding: 1.25rem;
+        background-color: #94d1f5;
+      `}
+    >
+      <Tabs {...args} />
+    </div>
+  ),
+  args: {
+    variant: 'primary',
+    tabItems: [
+      {
+        key: '1',
+        label: '보관한 편지',
+        content: (
+          <보관함Components.Content>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i}>from. 낯선 고양이.... 보관한 편지 내용... {i}</div>
+            ))}
+          </보관함Components.Content>
+        ),
+      },
+      {
+        key: '2',
+        label: '내가 보낸 편지',
+        content: (
+          <보관함Components.Content>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i}>
+                from. 낯선 고양이.... 내가 보낸 편지 내용... {i}
+              </div>
+            ))}
+          </보관함Components.Content>
+        ),
+      },
+    ],
+  },
+};

--- a/src/components/Tabs/index.stories.tsx
+++ b/src/components/Tabs/index.stories.tsx
@@ -19,7 +19,7 @@ export const Primary: Story = {
     <div
       css={css`
         padding: 1.25rem;
-        background-color: #94d1f5;
+        background-color: #8acef5;
       `}
     >
       <Tabs {...args} />
@@ -70,7 +70,7 @@ export const 보관함: Story = {
     <div
       css={css`
         padding: 1.25rem;
-        background-color: #94d1f5;
+        background-color: #8acef5;
       `}
     >
       <Tabs {...args} />

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import * as T from '@radix-ui/react-tabs';
+import styles, { type TabsVariant } from './styles';
+
+interface TabsProps {
+  /** 탭의 배경 색상과 스타일 등 테마를 지정합니다. */
+  variant?: TabsVariant;
+  /** 기본으로 활성화 되어 있을 탭 아이템의 key를 지정합니다.  */
+  defaultValue?: string;
+  /** 탭 아이템의 목록을 지정합니다. */
+  tabItems: {
+    key: string;
+    label: React.ReactNode;
+    content: React.ReactNode;
+  }[];
+}
+
+const Tabs = ({ variant = 'primary', defaultValue, tabItems }: TabsProps) => {
+  defaultValue = defaultValue ?? tabItems[0].key;
+
+  return (
+    <T.Root defaultValue={defaultValue}>
+      <T.List css={styles.list(variant)} aria-label="Tabs">
+        {tabItems.map((tabItem) => (
+          <T.Trigger
+            css={styles.trigger(variant)}
+            key={tabItem.key}
+            value={tabItem.key}
+          >
+            {tabItem.label}
+          </T.Trigger>
+        ))}
+      </T.List>
+
+      {tabItems.map((tabItem) => (
+        <T.Content key={tabItem.key} value={tabItem.key}>
+          {tabItem.content}
+        </T.Content>
+      ))}
+    </T.Root>
+  );
+};
+
+export default Tabs;
+export { default as tabsStyles } from './styles';

--- a/src/components/Tabs/styles.ts
+++ b/src/components/Tabs/styles.ts
@@ -28,15 +28,22 @@ const variantStyles = {
         rgb(255 255 255 / 0.7) 0%,
         rgb(255 255 255 / 0.1) 100%
       );
+      background-clip: padding-box;
     `,
     trigger: css`
+      margin: -1px;
       padding: 0.75rem 1rem;
-      border: none;
+      border: 1px solid transparent;
       border-radius: 0.75rem;
       background: none;
       color: #828282;
 
+      &:focus {
+        outline: none;
+      }
+
       &[data-state='active'] {
+        border: 1px solid rgb(255 255 255 / 0.3);
         background: linear-gradient(
           100deg,
           rgb(255 255 255 / 0.5) 6.09%,

--- a/src/components/Tabs/styles.ts
+++ b/src/components/Tabs/styles.ts
@@ -1,0 +1,53 @@
+import { css } from '@emotion/react';
+
+export type TabsVariant = 'primary';
+
+const styles = {
+  list: (variant: TabsVariant) => css`
+    display: flex;
+    width: 100%;
+
+    ${variantStyles[variant].list}
+  `,
+  trigger: (variant: TabsVariant) => css`
+    flex-grow: 1;
+    font-size: 0.875rem;
+    cursor: pointer;
+
+    ${variantStyles[variant].trigger};
+  `,
+};
+
+const variantStyles = {
+  primary: {
+    list: css`
+      border: 1px solid rgb(255 255 255 / 0.3);
+      border-radius: 0.75rem;
+      background: radial-gradient(
+        7463.97% 124.02% at 1.68% 0%,
+        rgb(255 255 255 / 0.7) 0%,
+        rgb(255 255 255 / 0.1) 100%
+      );
+    `,
+    trigger: css`
+      padding: 0.75rem 1rem;
+      border: none;
+      border-radius: 0.75rem;
+      background: none;
+      color: #828282;
+
+      &[data-state='active'] {
+        background: linear-gradient(
+          100deg,
+          rgb(255 255 255 / 0.5) 6.09%,
+          rgb(255 255 255 / 0.5) 100%,
+          rgb(255 255 255 / 0.3) 100%
+        );
+        color: black;
+        backdrop-filter: blur(2px);
+      }
+    `,
+  },
+};
+
+export default styles;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #24 

## ✅ 작업 사항
- Tabs 컴포넌트 작성
  - 탭의 디자인이 MUI 기본 형태와는 많이 달라보여서, radix ui 기반으로 작성했어요.
  - 현재는 `variant` 는 primary 하나로 되어있긴 한데.. 추후에 새로운 탭 디자인이 추가될 것을 고려해서 props를 만들어두었어요.

## 👩‍💻 공유 포인트 및 논의 사항
### Tabs 컴포넌트 사용 예시

```tsx
<Tabs
  tabItems={[
    {
      key: '1',
      label: '첫 번째',
      content: <div>컨텐츠 1</div>,
    },
    {
      key: '2',
      label: '두 번째',
      content: <div>컨텐츠 2</div>,
    },
    {
      key: '3',
      label: '세 번째',
      content: <div>컨텐츠 3</div>,
    },
  ]}
/>;
```

### background-clip 속성 관련
테두리가 피그마와 미세하게 다른 것 같아서 크기를 키워보았는데, 상하좌우의 색상이 다른 걸 발견했었어요.  😮

![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/b3e04468-52a9-4870-9fdc-2631ffc9e365)

원인은 [배경 색상이 테두리 영역까지 적용되는 것](https://stackoverflow.com/questions/4062001/can-you-set-a-border-opacity-in-css) 이었는데, background-clip 속성을 부여하니 해결됐어요.

그런데.. 사파리 브라우저에서는 `-webkit-background-clip` 속성으로 부여해줘야 하는데, [emotion 공식문서](https://emotion.sh/docs/introduction#framework-agnostic) 를 찾아보니 브라우저 별로 알아서 vendor-prefixing 를 붙혀준다는 것 같네요.. 그래서 background-clip 속성만 입력했어요.

제가 윈도우 환경이라 사파리 브라우저로는 실행을 못해봤지만.. [이 글](https://gist.github.com/Bananamilk452/51f7bd7d711b7675087a79bb80faca52#safari)을 참고해서 사파리랑 같은 Webkit 기반의 브라우저인 에피파니로 실행해보았을 때 이상은 없었어요!

### 크롬에서 실행 결과 (확대)
![탭](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/a46114c6-d8df-43b4-896e-541676450797)
