### PR TITLE
✨ feat: Bottom Sheet 컴포넌트 및 스토리북 작성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,18 @@
+import { useState } from 'react';
 import { Link, Outlet } from 'react-router-dom';
 import Background from '@/components/Background';
 import BackgroundImg from '@/assets/ocean.jpeg';
 import EmotionTestButton from '@/components/EmotionTestButton';
 import { ROUTER_PATHS } from '@/router';
+import BottomSheet from './components/BottomSheet';
 
 const App = () => {
+  const [open, setOpen] = useState(false);
+
+  const toggleDrawer = (newOpen: boolean) => () => {
+    setOpen(newOpen);
+  };
+
   return (
     <Background imageUrl={BackgroundImg}>
       <h1>
@@ -17,7 +25,19 @@ const App = () => {
       <Link to={ROUTER_PATHS.TEST_CONSTANT}>Test Constant Page</Link>
       <Link to={ROUTER_PATHS.TEST_VARIABLE('5')}>Test 5 Page</Link>
       <Outlet />
-      <button css={{ width: '100%' }}>하단버튼</button>
+      <button
+        css={{ width: '100%', height: '50px' }}
+        onClick={toggleDrawer(true)}
+      >
+        하단버튼
+      </button>
+      <BottomSheet
+        open={open}
+        onClose={toggleDrawer(false)}
+        onOpen={toggleDrawer(true)}
+      >
+        <h1 css={{ fontSize: '5rem' }}>안녕</h1>
+      </BottomSheet>
     </Background>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,10 @@
-import { useState } from 'react';
 import { Link, Outlet } from 'react-router-dom';
 import Background from '@/components/Background';
 import BackgroundImg from '@/assets/ocean.jpeg';
 import EmotionTestButton from '@/components/EmotionTestButton';
 import { ROUTER_PATHS } from '@/router';
-import BottomSheet from '@/components/BottomSheet';
 
 const App = () => {
-  const [open, setOpen] = useState(false);
-
-  const toggleDrawer = (newOpen: boolean) => () => {
-    setOpen(newOpen);
-  };
-
   return (
     <Background imageUrl={BackgroundImg}>
       <h1>
@@ -25,19 +17,7 @@ const App = () => {
       <Link to={ROUTER_PATHS.TEST_CONSTANT}>Test Constant Page</Link>
       <Link to={ROUTER_PATHS.TEST_VARIABLE('5')}>Test 5 Page</Link>
       <Outlet />
-      <button
-        css={{ width: '100%', height: '50px' }}
-        onClick={toggleDrawer(true)}
-      >
-        하단버튼
-      </button>
-      <BottomSheet
-        open={open}
-        onClose={toggleDrawer(false)}
-        onOpen={toggleDrawer(true)}
-      >
-        <h1 css={{ fontSize: '5rem' }}>안녕</h1>
-      </BottomSheet>
+      <button css={{ width: '100%' }}>하단버튼</button>
     </Background>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import Background from '@/components/Background';
 import BackgroundImg from '@/assets/ocean.jpeg';
 import EmotionTestButton from '@/components/EmotionTestButton';
 import { ROUTER_PATHS } from '@/router';
-import BottomSheet from './components/BottomSheet';
+import BottomSheet from '@/components/BottomSheet';
 
 const App = () => {
   const [open, setOpen] = useState(false);

--- a/src/components/Background/styles.ts
+++ b/src/components/Background/styles.ts
@@ -8,7 +8,7 @@ const style = {
     background-size: 37.5rem 100%;
     background-repeat: repeat-x;
 
-    @media (max-width: 768px) {
+    @media (max-width: 600px) {
       background-position: center;
       background-size: cover;
       background-repeat: no-repeat;

--- a/src/components/BottomSheet/index.stories.tsx
+++ b/src/components/BottomSheet/index.stories.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { css } from '@emotion/react';
+import Navbar from '../Navbar';
+import Button from '../Button';
+import BottomSheet from '.';
+
+const meta = {
+  title: 'Components/BottomSheet',
+  component: BottomSheet,
+  tags: ['autodocs'],
+} satisfies Meta<typeof BottomSheet>;
+
+export default meta;
+
+const styles = {
+  button: css`
+    width: 100%;
+    height: 50px;
+  `,
+  content: css`
+    padding-inline: 16px;
+  `,
+  navbar: css`
+    padding: 0;
+  `,
+};
+
+export const 바텀시트: StoryObj = {
+  render: () => {
+    const BottomSheetComponent = () => {
+      const [open, setOpen] = useState(false);
+
+      const toggleDrawer = (newOpen: boolean) => () => {
+        setOpen(newOpen);
+      };
+
+      return (
+        <>
+          <button css={styles.button} onClick={toggleDrawer(true)}>
+            바텀시트열기
+          </button>
+          <BottomSheet
+            open={open}
+            onClose={toggleDrawer(false)}
+            onOpen={toggleDrawer(true)}
+          >
+            <div css={styles.content}>
+              <h1>
+                바텀시트에 들어갈 내용입니다. 모바일에서는 스와이프로 닫을 수
+                있습니다.
+              </h1>
+              <h2>누구에게 보낼까요?</h2>
+            </div>
+            <Navbar css={styles.navbar}>
+              <Button variant="primary-unaccent" onClick={toggleDrawer(false)}>
+                닫기
+              </Button>
+              <Button variant="primary" onClick={toggleDrawer(false)}>
+                완료
+              </Button>
+            </Navbar>
+          </BottomSheet>
+        </>
+      );
+    };
+
+    return <BottomSheetComponent />;
+  },
+};

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import SwipeableDrawer from '@mui/material/SwipeableDrawer';
+import styles from './styles';
+
+interface BottomSheetProps extends React.ComponentPropsWithoutRef<'div'> {
+  open: boolean;
+  onClose: () => void;
+  onOpen: () => void;
+  children: React.ReactNode;
+}
+
+const BottomSheet = ({ open, onClose, onOpen, children }: BottomSheetProps) => {
+  return (
+    <SwipeableDrawer
+      anchor="bottom"
+      open={open}
+      onClose={onClose}
+      onOpen={onOpen}
+      transitionDuration={400}
+      PaperProps={{ style: styles.paper }}
+    >
+      <div />
+      <div>{children}</div>
+    </SwipeableDrawer>
+  );
+};
+
+export default BottomSheet;

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -3,9 +3,13 @@ import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import styles from './styles';
 
 interface BottomSheetProps extends React.ComponentPropsWithoutRef<'div'> {
+  /** 바텀시트의 열림(true), 닫힘(false) 상태입니다. */
   open: boolean;
+  /** 바텀 시트를 닫을 때 실행될 함수 입니다. */
   onClose: () => void;
+  /** 바텀 시트가 열릴 때 실행될 함수입니다. */
   onOpen: () => void;
+  /** BottomSheet 컴포넌트 안에 포함될 내용입니다. */
   children: React.ReactNode;
 }
 
@@ -20,7 +24,7 @@ const BottomSheet = ({ open, onClose, onOpen, children }: BottomSheetProps) => {
       PaperProps={{ style: styles.paper }}
     >
       <div css={styles.header} />
-      <div>{children}</div>
+      <div css={styles.content}>{children}</div>
     </SwipeableDrawer>
   );
 };

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -16,6 +16,7 @@ interface BottomSheetProps {
 const BottomSheet = ({ open, onClose, onOpen, children }: BottomSheetProps) => {
   return (
     <SwipeableDrawer
+      aria-autocomplete="inline"
       anchor="bottom"
       open={open}
       onClose={onClose}

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -19,7 +19,7 @@ const BottomSheet = ({ open, onClose, onOpen, children }: BottomSheetProps) => {
       transitionDuration={400}
       PaperProps={{ style: styles.paper }}
     >
-      <div />
+      <div css={styles.header} />
       <div>{children}</div>
     </SwipeableDrawer>
   );

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import styles from './styles';
 
-interface BottomSheetProps extends React.ComponentPropsWithoutRef<'div'> {
+interface BottomSheetProps {
   /** 바텀시트의 열림(true), 닫힘(false) 상태입니다. */
   open: boolean;
   /** 바텀 시트를 닫을 때 실행될 함수 입니다. */
@@ -21,7 +21,7 @@ const BottomSheet = ({ open, onClose, onOpen, children }: BottomSheetProps) => {
       onClose={onClose}
       onOpen={onOpen}
       transitionDuration={400}
-      PaperProps={{ style: styles.paper }}
+      PaperProps={{ sx: styles.paper }}
     >
       <div css={styles.header} />
       <div css={styles.content}>{children}</div>

--- a/src/components/BottomSheet/styles.ts
+++ b/src/components/BottomSheet/styles.ts
@@ -4,9 +4,8 @@ const style = {
   paper: {
     borderRadius: '16px 16px 0px 0px',
     margin: '0 auto',
-    overflowY: 'hidden' as const,
     maxWidth: '600px',
-    '@media (max-width: 600px)': {
+    '@media (maxWidth: 600px)': {
       width: '100%',
     },
   },
@@ -21,6 +20,8 @@ const style = {
   content: css`
     display: flex;
     flex-direction: column;
+    overflow-x: hidden;
+    overflow-y: hidden;
   `,
 };
 

--- a/src/components/BottomSheet/styles.ts
+++ b/src/components/BottomSheet/styles.ts
@@ -17,6 +17,11 @@ const style = {
     border-radius: 100px;
     background-color: var(--Gray-5, #e0e0e0);
   `,
+
+  content: css`
+    display: flex;
+    flex-direction: column;
+  `,
 };
 
 export default style;

--- a/src/components/BottomSheet/styles.ts
+++ b/src/components/BottomSheet/styles.ts
@@ -1,0 +1,13 @@
+const style = {
+  paper: {
+    borderRadius: '16px 16px 0px 0px',
+    margin: '0 auto',
+    overflowY: 'hidden' as const,
+    maxWidth: '600px',
+    '@media (max-width: 600px)': {
+      width: '100%',
+    },
+  },
+};
+
+export default style;

--- a/src/components/BottomSheet/styles.ts
+++ b/src/components/BottomSheet/styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { SxProps } from '@mui/material';
 
 const style = {
   paper: {
@@ -8,7 +9,7 @@ const style = {
     '@media (maxWidth: 600px)': {
       width: '100%',
     },
-  },
+  } satisfies SxProps,
   header: css`
     width: 60px;
     height: 4px;

--- a/src/components/BottomSheet/styles.ts
+++ b/src/components/BottomSheet/styles.ts
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+
 const style = {
   paper: {
     borderRadius: '16px 16px 0px 0px',
@@ -8,6 +10,13 @@ const style = {
       width: '100%',
     },
   },
+  header: css`
+    width: 60px;
+    height: 4px;
+    margin: 8px auto;
+    border-radius: 100px;
+    background-color: var(--Gray-5, #e0e0e0);
+  `,
 };
 
 export default style;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호

- close #23 

## ✅ 작업 사항

- Bottom Sheet 컴포넌트
  - MUI 의 `SwipeableDrawer` 를 사용하여 구현했습니다. 
  - 모바일에서는 스와이프 기능이 있지만, PC 에서는 없습니다.

https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/84aa94e7-0272-4ac7-ba38-ce2ecef754b1

  - `maxWidth: '600px'` 이라서 PC 배경 크기만큼 딱 맞습니다.

https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/3780fe29-283d-4ecb-b490-8ff93b5e5468
  
  - 안에 내용에 따라 세로 길이가 자동으로 조절됩니다.

## 👩‍💻 공유 포인트 및 논의 사항

### 사용 예시

사실 `onClose` `onOpen` 큰 차이를 모르겠는데 필수 항목이라 넣어야 한답니다.

```js
const [open, setOpen] = useState(false);

const toggleBottomSheet = (state: boolean) => () => {
    setOpen(state);
};

// 생략

<button onClick={toggleBottomSheet(true)}>
  바텀시트열기버튼
</button>
<BottomSheet
  open={open}
  onClose={toggleBottomSheet(false)}
  onOpen={toggleBottomSheet(true)}
>
  {/*들어갈 내용*/}
</BottomSheet>
```

### padding 값

bottom sheet 컨텐츠에 `padding-inline: 16px;` 을 주고 싶었는데 피그마 상으로 버튼이 양옆으로 붙어 있어서 안 넣었습니다.

<img width="400" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/1bc12073-400c-4539-bbd9-e7451af76990">


### paper 스타일

bottm sheet paper 스타일을 바꾸려는데 emotion 으로 안 되더라구요,, 그래서 다른 방법 사용해서 적용했습니다.
```css
  paper: {
    // 스타일
  },
 
```

```js
PaperProps={{ style: styles.paper }}
```