### PR TITLE
📦 chore: lint-pr 워크플로 작성

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,24 @@
+name: 'Lint PR'
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  main:
+    name: Title Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR 타이틀 체크
+        run: |
+          title=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
+          valid_types=("✨ feat: " "🚑 fix: " "💄 design: " "📝 style: " "🔨 refactor: " "💡 comment: " "📚 docs: " "✅ test: " "📦 chore: " "🚚 rename: " "➖ remove: " "🚀 deploy: " "🎉 init: ")
+          regex="^($(IFS=\|; echo "${valid_types[*]}"))"
+
+          echo "PR 타이틀: $title"
+          echo "유효한 정규식: $regex"
+
+          if [[ ! $title =~ $regex ]]; then
+            echo "error: PR 타이틀은 다음 문자열중 하나로 시작해야 해요: ${valid_types[*]}"
+            exit 1
+          fi


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #30 

## ✅ 작업 사항
Squash & Merge의 경우 PR의 제목이 main 브랜치에 커밋으로 들어가다보니, 타이틀을 체크하는 워크플로가 있으면 안정적이겠다는 생각에 작업해보았어요..

(원래 아무 타이틀이 없으면 브랜치 이름으로부터 유추해서 알아서 `📦 chore:` 같은 걸 붙혀주는 기능까지 작업해보려고 했는데.. 어려워서 체크하는 것 까지만 만들었어요.)

## 👩‍💻 공유 포인트 및 논의 사항
PR 타이틀이 특정한 문자로 시작하지 않는 경우에는 시각적으로 확인할 수 있어서 실수를 방지할 수 있어요.

![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/d082b778-6b88-4e82-9bf3-18ec0a9cdcef)

![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/58ed0c2e-645f-4588-9527-64012e610c54)
