### PR TITLE
✨ feat: Tooltip 컴포넌트, useTimeout 훅 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@hookform/resolvers": "^3.3.4",
         "@mui/material": "^5.15.5",
         "@radix-ui/react-tabs": "^1.0.4",
+        "@radix-ui/react-tooltip": "^1.0.7",
         "@tanstack/react-query": "^5.17.12",
         "axios": "^1.6.5",
         "clsx": "^2.1.0",
@@ -4055,7 +4056,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
       "integrity": "sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
@@ -4579,6 +4579,122 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.0.7.tgz",
+      "integrity": "sha512-lPh5iKNFVQ/jav/j6ZrWq3blfDJ0OH9R6FlNUHPMqdLuQ9vwDgFsRxvl8b7Asuy5c8xmoojHUxKHQSOAvMHxyw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+      "integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-escape-keydown": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-popper": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.3.tgz",
+      "integrity": "sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-rect": "1.0.1",
+        "@radix-ui/react-use-size": "1.0.1",
+        "@radix-ui/rect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+      "integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
@@ -4618,7 +4734,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
       "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "1.0.1"
@@ -4672,7 +4787,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz",
       "integrity": "sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/rect": "1.0.1"
@@ -4691,7 +4805,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz",
       "integrity": "sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-layout-effect": "1.0.1"
@@ -4710,7 +4823,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
       "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
@@ -4734,7 +4846,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.1.tgz",
       "integrity": "sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@hookform/resolvers": "^3.3.4",
     "@mui/material": "^5.15.5",
     "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-query": "^5.17.12",
     "axios": "^1.6.5",
     "clsx": "^2.1.0",

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import style, { ButtonVariant } from './styles';
 
 interface IconButtonProps extends React.ComponentProps<'button'> {
@@ -8,16 +8,16 @@ interface IconButtonProps extends React.ComponentProps<'button'> {
   children: React.ReactNode;
 }
 
-const IconButton = ({
-  variant = 'header',
-  children,
-  ...props
-}: IconButtonProps) => {
-  return (
-    <button {...props} css={style.button(variant)}>
-      {children}
-    </button>
-  );
-};
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ variant = 'header', children, ...props }, ref) => {
+    return (
+      <button {...props} ref={ref} css={style.button(variant)}>
+        {children}
+      </button>
+    );
+  },
+);
+
+IconButton.displayName = 'IconButton';
 
 export default IconButton;

--- a/src/components/Tooltip/index.stories.tsx
+++ b/src/components/Tooltip/index.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { css } from '@emotion/react';
+import { SoundOff } from '@/assets/icons';
+import IconButton from '../IconButton';
+import Tooltip from './';
+
+const meta = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const styles = {
+  background: css`
+    display: flex;
+    justify-content: flex-end;
+    padding: 1rem 1rem 3rem;
+    background-color: #9eddfc;
+  `,
+};
+
+export const Primary: Story = {
+  args: {
+    side: 'bottom',
+    align: 'end',
+    delay: 1000,
+    triggerContent: (
+      <IconButton>
+        <SoundOff color="white" />
+      </IconButton>
+    ),
+    children: '소리를 켜 바다를 느껴보세요',
+  },
+  decorators: (Story) => {
+    return (
+      <div css={styles.background}>
+        <Story />
+      </div>
+    );
+  },
+};

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import * as T from '@radix-ui/react-tooltip';
+import useTimeout from '@/hooks/useTimeout';
+import textStyles from '@/styles/textStyles';
+import styles from './styles';
+
+interface TooltipProps {
+  /** 툴팁의 위치를 지정합니다. */
+  side?: 'left' | 'top' | 'right' | 'bottom';
+  /** 화살표 모양의 위치를 지정합니다. */
+  align?: 'start' | 'center' | 'end';
+  /** 마운트시 최초로 툴팁을 보여줄 시간을 지정합니다. */
+  delay?: number;
+  /** 툴팁을 보여줄 트리거 컨텐츠를 지정합니다. */
+  triggerContent: React.ReactNode;
+  /** 툴팁 내용을 지정합니다. */
+  children?: React.ReactNode;
+}
+
+/** 마우스를 hover할 때 툴팁 컨텐츠를 보여주는 컴포넌트입니다. */
+const Tooltip = ({
+  side = 'bottom',
+  align = 'center',
+  delay = 0,
+  triggerContent,
+  children,
+}: TooltipProps) => {
+  const [isOpen, setIsOpen] = useState(delay > 0 ? true : false);
+
+  useTimeout(() => setIsOpen(false), delay);
+
+  return (
+    <T.Provider>
+      <T.Root open={isOpen} onOpenChange={setIsOpen}>
+        <T.Trigger asChild>{triggerContent}</T.Trigger>
+        <AnimatePresence>
+          {isOpen && (
+            <T.Portal forceMount>
+              <T.Content
+                css={[styles.content, textStyles.c1r]}
+                asChild
+                sideOffset={5}
+                align={align}
+                side={side}
+              >
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 10 }}
+                  transition={{ duration: 0.1 }}
+                >
+                  {children}
+                  <T.Arrow css={styles.arrow} />
+                </motion.div>
+              </T.Content>
+            </T.Portal>
+          )}
+        </AnimatePresence>
+      </T.Root>
+    </T.Provider>
+  );
+};
+
+export default Tooltip;

--- a/src/components/Tooltip/styles.ts
+++ b/src/components/Tooltip/styles.ts
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+
+const styles = {
+  content: css`
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.25rem;
+    background-color: white;
+    box-shadow:
+      0 0 4px 0 rgb(0 0 0 / 0.12),
+      2px 6px 12px 0 rgb(0 0 0 / 0.12);
+    text-align: center;
+  `,
+  arrow: css`
+    width: 0.75rem;
+    height: 0.5rem;
+    fill: white;
+  `,
+};
+
+export default styles;

--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * delay만큼 기다렸다가 callback을 실행하는 훅입니다.
+ */
+const useTimeout = (callback: VoidFunction, delay: number) => {
+  const callbackRef = useRef(callback);
+
+  // 마지막 callback을 저장
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  // delay 후에 callback 실행
+  useEffect(() => {
+    const timer = setTimeout(callbackRef.current, delay);
+    return () => clearTimeout(timer);
+  }, [delay]);
+};
+
+export default useTimeout;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #56 

## ✅ 작업 사항
- radix ui 기반으로 Tooltip 컴포넌트를 작성
- framer-motion을 활용해 트랜지션 효과 부여
- 특정 시간만큼 유예했다가 callback을 실행하는 `useTimeout` 훅 작성
  - (참고한 라이브러리: https://github.com/juliencrn/usehooks-ts/blob/master/packages/usehooks-ts/src/useTimeout/useTimeout.ts)
- IconButton 컴포넌트에 forwardRef 추가

## 👩‍💻 공유 포인트 및 논의 사항
### 사용법
```ts
interface TooltipProps {
  /** 툴팁의 위치를 지정합니다. */
  side?: 'left' | 'top' | 'right' | 'bottom';
  /** 화살표 모양의 위치를 지정합니다. */
  align?: 'start' | 'center' | 'end';
  /** 마운트시 최초로 툴팁을 보여줄 시간을 지정합니다. */
  delay?: number;
  /** 툴팁을 보여줄 트리거 컨텐츠를 지정합니다. */
  triggerContent: React.ReactNode;
  /** 툴팁 내용을 지정합니다. */
  children?: React.ReactNode;
}
```

side, align 속성으로 툴팁의 위치나 화살표 모양의 위치를 지정할 수 있어요.
delay 값을 주면 최초로 툴팁을 화면에서 보여주는 시간을 지정할 수 있어요.
triggerContent로 트리거 요소를 지정할 수 있고, children으로 툴팁 안에 보여줄 컨텐츠를 지정할 수 있어요.


### ref 관련 이슈 사항
![툴팁 안나오는 현상](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/636fa1cb-138f-465a-9d89-98dfc233fd40)

radix-ui의 툴팁 trigger 기능이 ref 요소를 사용하는지, IconButton에 마우스를 올려도 툴팁이 나타나지 않는 현상이 있었어요.
그래서 forwardRef 를 붙히는 작업을 했어요.

### 스토리 북
![툴팁 성공](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/a8f3fafc-ea80-4168-af5b-6d6984928e70)


