### PR TITLE
💄 design: 온보딩 페이지 디자인 변동 사항 반영

### DIFF
--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -23,6 +23,7 @@ export const Default: Story = {
   args: {
     variant: 'primary',
     size: 'md',
+    rounded: 'md',
     children: 'button',
     disabled: false,
   },

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -42,6 +42,9 @@ const styles = {
     padding: 1rem;
     background-color: #fcecd0;
   `,
+  cancelContainer: css`
+    display: flex;
+  `,
 };
 
 export const Primary: Story = {
@@ -99,6 +102,19 @@ export const SemiTransparent: Story = {
       <Button variant="semi-transparent">
         <PencilLine />
         <p>button</p>
+      </Button>
+    </div>
+  ),
+};
+
+export const Cancel: Story = {
+  render: () => (
+    <div css={styles.cancelContainer}>
+      <Button variant="cancel" rounded="none">
+        <p>닫기</p>
+      </Button>
+      <Button variant="primary" rounded="none">
+        <p>완료</p>
       </Button>
     </div>
   ),

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,19 +1,28 @@
 import React, { forwardRef } from 'react';
-import styles, { type ButtonSize, type ButtonVariant } from './styles';
+import styles, {
+  type ButtonSize,
+  type ButtonVariant,
+  type ButtonRounded,
+} from './styles';
 
 interface ButtonProps extends React.ComponentProps<'button'> {
   /** 버튼의 배경 색상과 폰트 색상을 지정합니다. */
   variant?: ButtonVariant;
   /** 버튼에 들어갈 패딩의 크기를 지정합니다. */
   size?: ButtonSize;
+  /** 버튼의 모서리의 둥근 정도를 지정합니다. */
+  rounded?: ButtonRounded;
   /** 버튼의 내용을 지정합니다. */
   children?: React.ReactNode;
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ variant = 'primary', size = 'md', children, ...props }, ref) => {
+  (
+    { variant = 'primary', size = 'md', rounded = 'md', children, ...props },
+    ref,
+  ) => {
     return (
-      <button css={styles.button(variant, size)} ref={ref} {...props}>
+      <button css={styles.button(variant, size, rounded)} ref={ref} {...props}>
         {children}
       </button>
     );

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -28,10 +28,13 @@ const styles = {
     cursor: pointer;
     transition: all 0.2s ease;
 
-    &:not(:disabled):active {
-      box-shadow: 0 2px 10px rgb(0 0 0 / 0.2);
-      transform: scale(0.98);
-    }
+    ${rounded !== 'none' &&
+    css`
+      &:not(:disabled):active {
+        box-shadow: 0 2px 10px rgb(0 0 0 / 0.2);
+        transform: scale(0.98);
+      }
+    `}
 
     &:disabled {
       box-shadow: none;

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -10,16 +10,20 @@ export type ButtonVariant =
   | 'semi-transparent-unaccent';
 
 export type ButtonSize = 'md' | 'sm';
+export type ButtonRounded = 'none' | 'sm' | 'md';
 
 const styles = {
-  button: (variant: ButtonVariant, size: ButtonSize) => css`
+  button: (
+    variant: ButtonVariant,
+    size: ButtonSize,
+    rounded: ButtonRounded,
+  ) => css`
     display: flex;
     flex: 1 0;
     gap: 0.5rem;
     justify-content: center;
     align-items: center;
     border: none;
-    border-radius: 6.25rem;
     cursor: pointer;
     transition: all 0.2s ease;
 
@@ -33,6 +37,7 @@ const styles = {
       cursor: not-allowed;
     }
 
+    ${roundedStyles[rounded]}
     ${textStyles.t3}
     ${sizeStyles[size]}
     ${variantStyles[variant]}
@@ -45,6 +50,18 @@ const sizeStyles = {
   `,
   md: css`
     padding: 1rem 1.25rem;
+  `,
+};
+
+const roundedStyles = {
+  none: css`
+    border-radius: none;
+  `,
+  sm: css`
+    border-radius: 0.75rem;
+  `,
+  md: css`
+    border-radius: 6.25rem;
   `,
 };
 

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -7,7 +7,8 @@ export type ButtonVariant =
   | 'primary-outline'
   | 'secondary'
   | 'semi-transparent'
-  | 'semi-transparent-unaccent';
+  | 'semi-transparent-unaccent'
+  | 'cancel';
 
 export type ButtonSize = 'md' | 'sm';
 export type ButtonRounded = 'none' | 'sm' | 'md';
@@ -125,6 +126,21 @@ const variantStyles = {
     );
     color: ${COLORS.gray3};
     box-shadow: 0 8px 16px 0 rgb(153 153 153 / 0.2);
+  `,
+  cancel: css`
+    background: ${COLORS.gray5};
+    color: ${COLORS.gray1};
+
+    &:hover {
+      background-color: ${COLORS.gray3};
+      color: black;
+    }
+
+    &:disabled {
+      background-color: ${COLORS.gray5};
+      color: ${COLORS.gray1};
+      opacity: 0.4;
+    }
   `,
 };
 

--- a/src/components/Chip/styles.ts
+++ b/src/components/Chip/styles.ts
@@ -71,6 +71,7 @@ const variants = {
     ${baseChipStyle};
     ${baseTextStyles};
     padding: 0.25rem 1rem;
+    background: rgb(255 255 255 / 0.8);
     border: 1px solid rgb(255 255 255 / 0.3);
     color: var(--kakao-logo, #000);
   `,

--- a/src/components/GenderCard/styles.ts
+++ b/src/components/GenderCard/styles.ts
@@ -47,7 +47,7 @@ const variantStyles = {
       ${selected &&
       css`
         border-color: ${COLORS.gray5};
-        background-color: ${COLORS.primary};
+        background-color: rgb(255 255 255 / 0.8);
       `}
     `,
     iconCircle: (selected: boolean) => css`
@@ -58,7 +58,7 @@ const variantStyles = {
       ${selected &&
       css`
         background-color: rgba(174 226 245 / 1);
-        color: black;
+        color: ${COLORS.primary};
       `};
     `,
   },

--- a/src/components/Header/index.stories.tsx
+++ b/src/components/Header/index.stories.tsx
@@ -95,7 +95,7 @@ export const 메인_페이지: Story = {
   ...Primary,
   render: () => (
     <Header
-      variant="none"
+      variant="primary"
       leftContent={
         <div css={styles.메인_페이지.countChip}>
           <div css={styles.메인_페이지.emptyBox} />
@@ -124,7 +124,7 @@ export const 흘러온_편지: Story = {
   ...Primary,
   render: () => (
     <Header
-      variant="none"
+      variant="primary"
       leftContent={
         <>
           <CaretLeft css={styles.icon} strokeWidth={2} />
@@ -147,18 +147,7 @@ export const 보관함_편지: Story = {
   ...Primary,
   render: () => (
     <Header
-      variant="none"
-      leftContent={<CaretLeft css={styles.icon} strokeWidth={2} />}
-      centerContent={<>보관함</>}
-    />
-  ),
-};
-
-export const 보관함_편지_Secondary: Story = {
-  ...Primary,
-  render: () => (
-    <Header
-      variant="secondary"
+      variant="primary"
       leftContent={<CaretLeft css={styles.icon} strokeWidth={2} />}
       centerContent={<>보관함</>}
     />

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
-import COLORS from '@/constants/colors';
 
-export type HeaderVariant = 'primary' | 'secondary' | 'none';
+export type HeaderVariant = 'primary' | 'none';
 
 const styles = {
   header: (variant: HeaderVariant) => css`
@@ -14,8 +13,7 @@ const styles = {
     font-weight: 700;
     font-size: 0.875rem;
 
-    ${variant === 'primary' && primary.header}
-    ${variant === 'secondary' && secondary.header}
+    ${variants[variant]}
   `,
   left: css`
     position: absolute;
@@ -37,26 +35,16 @@ const styles = {
   `,
 };
 
-const primary = {
-  header: css`
-    border-bottom: 1px solid rgb(255 255 255 / 0.12);
+const variants = {
+  primary: css`
     background: linear-gradient(
-      180deg,
-      rgb(255 255 255 / 0.2) 0%,
-      rgb(255 255 255 / 0.1) 98%
+      178deg,
+      #67ccff 2.02%,
+      rgb(104 205 255 / 0) 97.99%
     );
     color: white;
-    backdrop-filter: blur(4px);
   `,
-};
-
-const secondary = {
-  header: css`
-    border-bottom: 1px solid rgb(255 255 255 / 0.12);
-    background: rgb(255 255 255 / 0.75);
-    color: ${COLORS.gray2};
-    backdrop-filter: blur(40px);
-  `,
+  none: css(),
 };
 
 export default styles;

--- a/src/components/Navbar/index.stories.tsx
+++ b/src/components/Navbar/index.stories.tsx
@@ -90,7 +90,7 @@ export const 편지_작성하기: Story = {
       </Button>
       <div
         css={[
-          buttonStyles.button('semi-transparent', 'sm'),
+          buttonStyles.button('semi-transparent', 'sm', 'md'),
           styles.편지_작성하기.iconContainer,
         ]}
       >

--- a/src/pages/OnboardingPage/steps/InputBirthdayStep.tsx
+++ b/src/pages/OnboardingPage/steps/InputBirthdayStep.tsx
@@ -44,7 +44,11 @@ const formSchema = z.object({
 type Inputs = z.infer<typeof formSchema>;
 
 const InputBirthdayStep = () => {
-  const { register, handleSubmit } = useForm<Inputs>({
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid },
+  } = useForm<Inputs>({
     resolver: zodResolver(formSchema),
   });
 
@@ -95,7 +99,7 @@ const InputBirthdayStep = () => {
           type="submit"
           variant="primary"
           onClick={handleSubmit(onSubmit, onError)}
-          disabled={isPending}
+          disabled={isPending || !isValid}
         >
           {isPending ? <LoadingSpinner size="1.3rem" /> : '다음'}
         </Button>

--- a/src/pages/OnboardingPage/steps/InputGenderStep.tsx
+++ b/src/pages/OnboardingPage/steps/InputGenderStep.tsx
@@ -30,7 +30,11 @@ const InputGenderStep = () => {
   return (
     <StepTemplate
       buttonContent={
-        <Button variant="primary" onClick={handleSubmit} disabled={isPending}>
+        <Button
+          variant="primary"
+          onClick={handleSubmit}
+          disabled={isPending || !gender}
+        >
           {isPending ? <LoadingSpinner size="1.3rem" /> : '선택 완료'}
         </Button>
       }

--- a/src/pages/OnboardingPage/steps/InputWorryStep.tsx
+++ b/src/pages/OnboardingPage/steps/InputWorryStep.tsx
@@ -68,7 +68,7 @@ const InputWorryStep = () => {
         <Button
           variant="primary"
           onClick={handleSubmit}
-          disabled={isSubmitting}
+          disabled={isSubmitting || selectedWorries.length === 0}
         >
           {isSubmitting ? <LoadingSpinner size="1.3rem" /> : '선택 완료'}
         </Button>

--- a/src/pages/OnboardingPage/styles.ts
+++ b/src/pages/OnboardingPage/styles.ts
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import textStyles from '@/styles/textStyles';
+import COLORS from '@/constants/colors';
 
 const styles = {
   container: css`
@@ -20,10 +21,14 @@ const styles = {
       rgb(255 255 255 / 0.56) 0%,
       rgb(255 255 255 / 0.24) 100%
     );
-    color: black;
+    color: ${COLORS.gray1};
     outline: none;
     text-align: center;
     backdrop-filter: blur(7.5px);
+
+    &:focus {
+      background: rgb(255 255 255 / 0.8);
+    }
 
     ${textStyles.t3}
   `,


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #70 

## ✅ 작업 사항
- 주로 온보딩에서 사용되는 컴포넌트들의 디자인 변동 사항을 반영했어요.
- 다음 스텝으로 넘어가기 이전에 정보를 입력하지 않으면 버튼을 disabled 처리했어요.

![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/890b2e15-5156-47af-b7ce-b8c2ba56370e)


## 👩‍💻 공유 포인트 및 논의 사항
### Button 컴포넌트
- 둥근 정도를 나타내는 rounded prop이 추가되었어요.
- cancel variant가 추가되었어요.
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/a07a22a8-9b8e-486b-a999-cf3d4b7d26b4)

### Header 컴포넌트
- secondary variant가 제거되었어요.
- primary variant에 linear 그라데이션 효과가 추가되었어요.
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/ac841e7d-0d41-418d-8b17-5f038085136d)

### Chip 컴포넌트
- primary-selected의 배경이 변경되었어요.
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/8f381c07-025c-4792-9434-0e262f1ca1bb)

### GenderCard 컴포넌트
- 선택 시 스타일이 변경되었어요.
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/168b4f47-f98e-4cfe-8dd8-55de85a94e1d)
