### PR TITLE
✨ feat: 메인 페이지의 TimeChip 시간 표현

### DIFF
--- a/src/mocks/datas/letter.ts
+++ b/src/mocks/datas/letter.ts
@@ -3,7 +3,9 @@ import letterAPI from '@/api/letter/apis';
 
 export const ReceivedLetterResponse = [
   {
-    createdAt: '2024-02-05T15:40:44',
+    createdAt: new Date(
+      new Date().getTime() - 48 * 60 * 60 * 1000 + 2 * 60 * 1000,
+    ).toISOString(),
     letterId: 3,
     senderNickname: '낯선 소',
     receiverNickname: '낯선 유저1',
@@ -11,7 +13,9 @@ export const ReceivedLetterResponse = [
     worryType: 'BREAK_LOVE',
   },
   {
-    createdAt: '2024-02-05T15:40:44',
+    createdAt: new Date(
+      new Date().getTime() - 48 * 60 * 60 * 1000 + 60 * 60 * 1000,
+    ).toISOString(),
     letterId: 4,
     senderNickname: '낯선 소',
     receiverNickname: '낯선 유저2',
@@ -19,7 +23,9 @@ export const ReceivedLetterResponse = [
     worryType: 'WORK',
   },
   {
-    createdAt: '2024-02-05T15:40:44',
+    createdAt: new Date(
+      new Date().getTime() - 23 * 60 * 60 * 1000,
+    ).toISOString(),
     letterId: 5,
     senderNickname: '낯선 소',
     receiverNickname: '낯선 유저3',
@@ -27,7 +33,9 @@ export const ReceivedLetterResponse = [
     worryType: 'COURSE',
   },
   {
-    createdAt: '2024-02-05T15:40:44',
+    createdAt: new Date(
+      new Date().getTime() - 1 * 60 * 60 * 1000,
+    ).toISOString(),
     letterId: 6,
     senderNickname: '낯선 소',
     receiverNickname: '낯선 유저4',

--- a/src/pages/MainPage/components/CarouselArea/index.tsx
+++ b/src/pages/MainPage/components/CarouselArea/index.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import useEmblaCarousel from 'embla-carousel-react';
-import { CaretLeft, CaretRight, HourGlass } from '@/assets/icons';
+import { CaretLeft, CaretRight } from '@/assets/icons';
 import IconButton from '@/components/IconButton';
 import COLORS from '@/constants/colors';
-import Chip from '@/components/Chip';
-import textStyles from '@/styles/textStyles';
 import useLetterSlides from '../../hooks/useLetterSlides';
+import TimeChip from '../TimeChip';
 import styles from './styles';
 import { BOTTLES_LETTER, BOTTLES_REPLY } from './bottleData';
 
@@ -46,13 +45,10 @@ const CarouselArea = () => {
                       )
                     }
                   />
-                  <Chip
-                    variant="bottle-tag"
-                    css={[styles.timeChip, BOTTLES_LETTER[idx]?.chipPosition]}
-                  >
-                    <HourGlass width="1rem" height="1rem" />
-                    <p css={textStyles.b4m}>00h</p>
-                  </Chip>
+                  <TimeChip
+                    css={BOTTLES_LETTER[idx]?.chipPosition}
+                    createdAt={letter.createdAt}
+                  />
                 </div>
               ))}
 

--- a/src/pages/MainPage/components/CarouselArea/styles.ts
+++ b/src/pages/MainPage/components/CarouselArea/styles.ts
@@ -44,10 +44,6 @@ const styles = {
   bottleImage: css`
     cursor: pointer;
   `,
-  timeChip: css`
-    padding: 0.125rem 0.75rem;
-    cursor: default;
-  `,
 };
 
 export default styles;

--- a/src/pages/MainPage/components/TimeChip/index.stories.tsx
+++ b/src/pages/MainPage/components/TimeChip/index.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TimeChip from './';
+
+const meta = {
+  title: 'Pages/MainPage/TimeChip',
+  component: TimeChip,
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof TimeChip>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    createdAt: new Date(
+      new Date().getTime() - 23 * 60 * 60 * 1000,
+    ).toISOString(),
+  },
+};

--- a/src/pages/MainPage/components/TimeChip/index.tsx
+++ b/src/pages/MainPage/components/TimeChip/index.tsx
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { HourGlass } from '@/assets/icons';
+import Chip from '@/components/Chip';
+import textStyles from '@/styles/textStyles';
+import COLORS from '@/constants/colors';
+import { formatTimechipDate } from '@/utils/dateUtils';
+import styles from './styles';
+
+interface TimeChipProps {
+  createdAt: string;
+}
+
+const TimeChip = ({ createdAt, ...props }: TimeChipProps) => {
+  const expiredAt = useMemo(
+    () => new Date(new Date(createdAt).getTime() + 48 * 60 * 60 * 1000),
+    [createdAt],
+  );
+
+  const timeText = formatTimechipDate(new Date(), expiredAt);
+  const isAlmostExpired = timeText.at(-1) !== 'h';
+
+  return (
+    <Chip variant="bottle-tag" css={styles.timeChip} {...props}>
+      <HourGlass
+        width="1rem"
+        height="1rem"
+        color={isAlmostExpired ? COLORS.red : COLORS.gray3}
+      />
+      <p
+        css={[
+          textStyles.b4m,
+          css({ color: isAlmostExpired ? COLORS.red : COLORS.gray1 }),
+        ]}
+      >
+        {timeText}
+      </p>
+    </Chip>
+  );
+};
+
+export default TimeChip;

--- a/src/pages/MainPage/components/TimeChip/styles.ts
+++ b/src/pages/MainPage/components/TimeChip/styles.ts
@@ -1,0 +1,10 @@
+import { css } from '@emotion/react';
+
+const styles = {
+  timeChip: css`
+    padding: 0.125rem 0.75rem;
+    cursor: default;
+  `,
+};
+
+export default styles;

--- a/src/pages/OnboardingPage/components/NavHeader/index.stories.tsx
+++ b/src/pages/OnboardingPage/components/NavHeader/index.stories.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import NavHeader from './';
 
 const meta = {
-  title: 'OnboardingPage/Components/NavHeader',
+  title: 'Pages/OnboardingPage/Components/NavHeader',
   component: NavHeader,
   tags: ['autodocs'],
   argTypes: {},

--- a/src/pages/OnboardingPage/components/Progress/index.stories.tsx
+++ b/src/pages/OnboardingPage/components/Progress/index.stories.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import Progress from './';
 
 const meta = {
-  title: 'OnboardingPage/Components/Progress',
+  title: 'Pages/OnboardingPage/Components/Progress',
   component: Progress,
   tags: ['autodocs'],
   argTypes: {},

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -92,7 +92,6 @@ describe('getTimeDifference', () => {
       second: 1,
       minute: 0,
       hour: 0,
-      day: 0,
     });
 
     expect(
@@ -104,7 +103,6 @@ describe('getTimeDifference', () => {
       second: 60,
       minute: 1,
       hour: 0,
-      day: 0,
     });
 
     expect(
@@ -116,7 +114,6 @@ describe('getTimeDifference', () => {
       second: 3600,
       minute: 60,
       hour: 1,
-      day: 0,
     });
 
     expect(
@@ -128,7 +125,6 @@ describe('getTimeDifference', () => {
       second: 86400,
       minute: 1440,
       hour: 24,
-      day: 1,
     });
 
     expect(
@@ -140,7 +136,6 @@ describe('getTimeDifference', () => {
       second: 31536000,
       minute: 525600,
       hour: 8760,
-      day: 365,
     });
   });
 
@@ -154,7 +149,6 @@ describe('getTimeDifference', () => {
       second: 0,
       minute: 0,
       hour: 0,
-      day: 0,
     });
   });
 

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -9,20 +9,6 @@ describe('formatTimechipDate', () => {
     expect(
       formatTimechipDate(
         new Date('2021-01-01T00:00:00'),
-        new Date('2021-01-01T00:00:01'),
-      ),
-    ).toBe('01s');
-
-    expect(
-      formatTimechipDate(
-        new Date('2021-01-01T00:00:00'),
-        new Date('2021-01-01T00:00:59'),
-      ),
-    ).toBe('59s');
-
-    expect(
-      formatTimechipDate(
-        new Date('2021-01-01T00:00:00'),
         new Date('2021-01-01T00:01:00'),
       ),
     ).toBe('01m');
@@ -49,13 +35,13 @@ describe('formatTimechipDate', () => {
     ).toBe('48h');
   });
 
-  it('from이 to보다 크면 00s를 반환해야 한다.', () => {
+  it('from이 to보다 크면 00m을 반환해야 한다.', () => {
     expect(
       formatTimechipDate(
         new Date('2022-01-01T00:00:00'),
         new Date('2021-01-01T00:00:00'),
       ),
-    ).toBe('00s');
+    ).toBe('00m');
   });
 
   it('유효하지 않은 Date 객체가 들어오면 에러를 반환해야 한다', () => {

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -1,0 +1,170 @@
+import {
+  formatTimechipDate,
+  getTimeDifference,
+  isValidDate,
+} from './dateUtils';
+
+describe('formatTimechipDate', () => {
+  it('두 날짜의 차이를 TimeChip에서 사용되는 문자열 형태로 반환해야 한다', () => {
+    expect(
+      formatTimechipDate(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-01T00:00:01'),
+      ),
+    ).toBe('01s');
+
+    expect(
+      formatTimechipDate(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-01T00:00:59'),
+      ),
+    ).toBe('59s');
+
+    expect(
+      formatTimechipDate(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-01T00:01:00'),
+      ),
+    ).toBe('01m');
+
+    expect(
+      formatTimechipDate(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-01T00:59:00'),
+      ),
+    ).toBe('59m');
+
+    expect(
+      formatTimechipDate(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-01T01:00:00'),
+      ),
+    ).toBe('01h');
+
+    expect(
+      formatTimechipDate(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-03T00:00:00'),
+      ),
+    ).toBe('48h');
+  });
+
+  it('from이 to보다 크면 00s를 반환해야 한다.', () => {
+    expect(
+      formatTimechipDate(
+        new Date('2022-01-01T00:00:00'),
+        new Date('2021-01-01T00:00:00'),
+      ),
+    ).toBe('00s');
+  });
+
+  it('유효하지 않은 Date 객체가 들어오면 에러를 반환해야 한다', () => {
+    expect(() => {
+      formatTimechipDate(new Date('이상한문자열'), new Date());
+    }).toThrowError('Invalid Date');
+
+    expect(() => {
+      formatTimechipDate(new Date(), new Date('이상한문자열'));
+    }).toThrowError('Invalid Date');
+  });
+});
+
+describe('isValidDate', () => {
+  it('정상적인 Date 객체이면 true를, 아니면 false를 반환해야 한다', () => {
+    expect(isValidDate(new Date())).toBe(true);
+    expect(isValidDate(new Date('December 17, 1995 03:24:00'))).toBe(true);
+    expect(isValidDate(new Date(1995, 11, 17, 3, 24, 0))).toBe(true);
+    expect(isValidDate(new Date(1995, 11, 17))).toBe(true);
+    expect(isValidDate(new Date('2021-01-01'))).toBe(true);
+    expect(isValidDate(new Date('2021-01-01T00:00:00'))).toBe(true);
+    expect(isValidDate(new Date('이상한문자열'))).toBe(false);
+  });
+});
+
+describe('getTimeDifference', () => {
+  it('두 날짜의 차이를 반환해야 한다', () => {
+    expect(
+      getTimeDifference(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-01T00:00:01'),
+      ),
+    ).toEqual({
+      second: 1,
+      minute: 0,
+      hour: 0,
+      day: 0,
+    });
+
+    expect(
+      getTimeDifference(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-01T00:01:00'),
+      ),
+    ).toEqual({
+      second: 60,
+      minute: 1,
+      hour: 0,
+      day: 0,
+    });
+
+    expect(
+      getTimeDifference(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-01T01:00:00'),
+      ),
+    ).toEqual({
+      second: 3600,
+      minute: 60,
+      hour: 1,
+      day: 0,
+    });
+
+    expect(
+      getTimeDifference(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2021-01-02T00:00:00'),
+      ),
+    ).toEqual({
+      second: 86400,
+      minute: 1440,
+      hour: 24,
+      day: 1,
+    });
+
+    expect(
+      getTimeDifference(
+        new Date('2021-01-01T00:00:00'),
+        new Date('2022-01-01T00:00:00'),
+      ),
+    ).toEqual({
+      second: 31536000,
+      minute: 525600,
+      hour: 8760,
+      day: 365,
+    });
+  });
+
+  it('from이 to보다 크면 시간 차이는 마이너스가 아닌 0을 반환해야 한다.', () => {
+    expect(
+      getTimeDifference(
+        new Date('2022-01-01T00:00:00'),
+        new Date('2021-01-01T00:00:00'),
+      ),
+    ).toEqual({
+      second: 0,
+      minute: 0,
+      hour: 0,
+      day: 0,
+    });
+  });
+
+  it('유효하지 않은 Date 객체가 들어오면 에러를 반환해야 한다', () => {
+    expect(() => {
+      getTimeDifference(new Date('이상한문자열'), new Date());
+    }).toThrowError('Invalid Date');
+
+    expect(() => {
+      getTimeDifference(new Date(), new Date('이상한문자열'));
+    }).toThrowError('Invalid Date');
+  });
+});

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -35,9 +35,8 @@ const getTimeDifference = (from: Date, to: Date) => {
   const second = Math.max(Math.floor(diff / 1000), 0);
   const minute = Math.max(Math.floor(diff / (1000 * 60)), 0);
   const hour = Math.max(Math.floor(diff / (1000 * 60 * 60)), 0);
-  const day = Math.max(Math.floor(diff / (1000 * 60 * 60 * 24)), 0);
 
-  return { second, minute, hour, day };
+  return { second, minute, hour };
 };
 
 export { formatDate, isValidDate, getTimeDifference, formatTimechipDate };

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -8,14 +8,12 @@ const formatDate = (date: Date): string => {
 
 /** 시간 차이를 계산한 뒤, TimeChip에서 사용되는 문자열 형태로 반환 */
 const formatTimechipDate = (from: Date, to: Date): string => {
-  const { second, minute, hour } = getTimeDifference(from, to);
+  const { minute, hour } = getTimeDifference(from, to);
 
   if (hour > 0) {
     return `${hour}h`.padStart(3, '0');
-  } else if (minute > 0) {
-    return `${minute}m`.padStart(3, '0');
   } else {
-    return `${second}s`.padStart(3, '0');
+    return `${minute}m`.padStart(3, '0');
   }
 };
 

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -6,4 +6,38 @@ const formatDate = (date: Date): string => {
   return `${year}년 ${month}월 ${day}일`;
 };
 
-export { formatDate };
+/** 시간 차이를 계산한 뒤, TimeChip에서 사용되는 문자열 형태로 반환 */
+const formatTimechipDate = (from: Date, to: Date): string => {
+  const { second, minute, hour } = getTimeDifference(from, to);
+
+  if (hour > 0) {
+    return `${hour}h`.padStart(3, '0');
+  } else if (minute > 0) {
+    return `${minute}m`.padStart(3, '0');
+  } else {
+    return `${second}s`.padStart(3, '0');
+  }
+};
+
+/** Date 객체가 정상적인지 확인 */
+const isValidDate = (date: Date): boolean => {
+  return date instanceof Date && !isNaN(date as unknown as number);
+};
+
+/** 두 Date 객체의 시간 차이 반환 */
+const getTimeDifference = (from: Date, to: Date) => {
+  if (!isValidDate(from) || !isValidDate(to)) {
+    throw new Error('Invalid Date');
+  }
+
+  const diff = to.getTime() - from.getTime();
+
+  const second = Math.max(Math.floor(diff / 1000), 0);
+  const minute = Math.max(Math.floor(diff / (1000 * 60)), 0);
+  const hour = Math.max(Math.floor(diff / (1000 * 60 * 60)), 0);
+  const day = Math.max(Math.floor(diff / (1000 * 60 * 60 * 24)), 0);
+
+  return { second, minute, hour, day };
+};
+
+export { formatDate, isValidDate, getTimeDifference, formatTimechipDate };


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #88

## ✅ 작업 사항
메인 페이지에서 사용되는 TimeChip 컴포넌트를 만들었어요.
- 시간은 OOh 로 표현
- 분은 OOm로 표현 (빨간색)
- 초는 OOs로 표현 (빨간색)
  - 우선 second 까지 표현하도록 유틸 함수를 만들어 놓긴 했는데, minute 까지만 처리 하는 게 나으려나요?? 

![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/2e2dd391-6913-4733-98e0-a9a2786e88ef)

## 👩‍💻 공유 포인트 및 논의 사항
날짜 관련 몇 가지 유틸 함수와 테스트 코드를 작성했어요.

```ts
/** 시간 차이를 계산한 뒤, TimeChip에서 사용되는 문자열 형태로 반환 */
const formatTimechipDate = (from: Date, to: Date): string => {
  const { second, minute, hour } = getTimeDifference(from, to);

  if (hour > 0) {
    return `${hour}h`.padStart(3, '0');
  } else if (minute > 0) {
    return `${minute}m`.padStart(3, '0');
  } else {
    return `${second}s`.padStart(3, '0');
  }
};
```
