### PR TITLE
✨ feat: 흘러온 편지 페이지 API 구현

### DIFF
--- a/src/api/letter/apis.ts
+++ b/src/api/letter/apis.ts
@@ -53,13 +53,21 @@ const letterAPI = {
   },
 
   /** 받은 편지 답장 */
-  patchReceptionReply: async (
-    letterId: number,
-    params: { replyContent: string },
-  ) => {
+  patchReceptionReply: async ({
+    letterId,
+    body,
+  }: {
+    letterId: number;
+    body: FormData;
+  }) => {
     const { data } = await authInstance.patch(
       `api/letter/reception/reply/${letterId}`,
-      params,
+      body,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
     );
     return data;
   },

--- a/src/api/letter/apis.ts
+++ b/src/api/letter/apis.ts
@@ -1,6 +1,6 @@
-import { Letter } from '@/types/letter';
+import { Letter, Reception } from '@/types/letter';
 import { Worry } from '@/constants/users';
-import { baseInstance } from '../instance';
+import { baseInstance, authInstance } from '../instance';
 
 const letterAPI = {
   /** 받은 편지 전체 조회 */
@@ -40,7 +40,35 @@ const letterAPI = {
 
   /** 편지 작성 */
   postLetter: async (letter: Letter) => {
-    const { data } = await baseInstance.post('/api/letter', letter);
+    const { data } = await authInstance.post('/api/letter', letter);
+    return data;
+  },
+
+  /** 보낸 편지 단건 조회 */
+  getSingleReception: async (letterId: number) => {
+    const { data } = await authInstance.get<Reception>(
+      `/api/letter/reception/${letterId}`,
+    );
+    return data;
+  },
+
+  /** 받은 편지 답장 */
+  patchReceptionReply: async (
+    letterId: number,
+    params: { replyContent: string },
+  ) => {
+    const { data } = await authInstance.patch(
+      `api/letter/reception/reply/${letterId}`,
+      params,
+    );
+    return data;
+  },
+
+  /** 받은 편지 토스 */
+  patchReceptionToss: async (letterId: number) => {
+    const { data } = await authInstance.patch(
+      `/api/letter/reception/toss/${letterId}`,
+    );
     return data;
   },
 };

--- a/src/api/letter/queryOptions.ts
+++ b/src/api/letter/queryOptions.ts
@@ -22,3 +22,5 @@ const letterOptions = {
       queryFn: () => letterAPI.getSingleReception(letterId),
     }),
 };
+
+export default letterOptions;

--- a/src/api/letter/queryOptions.ts
+++ b/src/api/letter/queryOptions.ts
@@ -15,6 +15,10 @@ const letterOptions = {
       queryKey: [...letterOptions.all, 'reply', page] as const,
       queryFn: () => letterAPI.getRepliedLetters(page),
     }),
-};
 
-export default letterOptions;
+  singleReception: (letterId: number) =>
+    queryOptions({
+      queryKey: [...letterOptions.all, 'reception', letterId] as const,
+      queryFn: () => letterAPI.getSingleReception(letterId),
+    }),
+};

--- a/src/components/LetterAccordion/styles.ts
+++ b/src/components/LetterAccordion/styles.ts
@@ -30,7 +30,6 @@ const style = {
     position: absolute;
     top: 0;
     left: 0;
-    z-index: 2;
     display: -webkit-box; /* stylelint-disable-line value-no-vendor-prefix */
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -2,6 +2,7 @@ const ERROR_RESPONSES = {
   accessExpired: '액세스 토큰이 만료되었습니다.',
   reissueFailed: '리프레시 토큰이 올바르지 않습니다. 다시 로그인해주세요.',
   usernameNotFound: '존재하지 않는 회원입니다.',
+  accessDeniedLetter: '해당 편지에 접근할 수 없습니다.',
 } as const;
 
 export default ERROR_RESPONSES;

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse, delay } from 'msw';
 import { baseURL } from '@/utils/mswUtils';
 import QUERY_STRINGS from '@/constants/queryStrings';
+import { Reception } from '@/types/letter';
 import {
   ReceivedLetterResponse,
   RepliedLettersResponse,
@@ -39,6 +40,33 @@ const letterHandler = [
 
   http.post(baseURL('/api/letter'), async () => {
     await delay(1000);
+    return HttpResponse.json();
+  }),
+
+  http.get(baseURL('/api/letter/reception/:letterId'), async (req) => {
+    await delay(300);
+
+    const result: Reception = {
+      createdAt: '2024-02-05T15:40:44',
+      letterId: Number(req.params.letterId),
+      senderNickname: '낯선 고양이123',
+      receiverNickname: '낯선 강아지456',
+      content: `${req.params.letterId} 번째 편지 입니다. 여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대 부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오`,
+      worryType: 'BREAK_LOVE',
+    };
+
+    return HttpResponse.json(result);
+  }),
+
+  http.patch(baseURL('/api/letter/reception/reply/:letterId'), async () => {
+    await delay(1000);
+
+    return HttpResponse.json();
+  }),
+
+  http.patch(baseURL('/api/letter/reception/toss/:letterId'), async () => {
+    await delay(1000);
+
     return HttpResponse.json();
   }),
 ];

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse, delay } from 'msw';
 import { baseURL } from '@/utils/mswUtils';
 import QUERY_STRINGS from '@/constants/queryStrings';
 import { Reception } from '@/types/letter';
+import ERROR_RESPONSES from '@/constants/errorMessages';
 import {
   ReceivedLetterResponse,
   RepliedLettersResponse,
@@ -45,6 +46,16 @@ const letterHandler = [
 
   http.get(baseURL('/api/letter/reception/:letterId'), async (req) => {
     await delay(300);
+
+    const mswCase = new URLSearchParams(window.location.search).get(
+      QUERY_STRINGS.mswCase,
+    );
+
+    if (mswCase === '400') {
+      return new HttpResponse(ERROR_RESPONSES.accessDeniedLetter, {
+        status: 400,
+      });
+    }
 
     const result: Reception = {
       createdAt: '2024-02-05T15:40:44',

--- a/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
@@ -5,9 +5,9 @@ import Tooltip from '@/components/Tooltip';
 import LetterHeader from '@/components/LetterHeader';
 import Chip from '@/components/Chip';
 import { formatDate } from '@/utils/dateUtils';
-import { ReceptionLetterType } from '../hooks/useLetterTag';
-import LetterContent from '../components/LetterContent';
 import ReceptionPolaroid from '../components/ReceptionPolaroid';
+import LetterContent from '../components/LetterContent';
+import { ReceptionLetterType } from '../hooks/useLetterTag';
 import style from './styles';
 
 interface ReceivedLetterProps {

--- a/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
 import LetterCard from '@/components/LetterCard';
 import Navbar from '@/components/Navbar';
 import Button from '@/components/Button';
@@ -5,18 +7,30 @@ import Tooltip from '@/components/Tooltip';
 import LetterHeader from '@/components/LetterHeader';
 import Chip from '@/components/Chip';
 import { formatDate } from '@/utils/dateUtils';
-import ReceptionPolaroid from '../components/ReceptionPolaroid';
-import LetterContent from '../components/LetterContent';
+import letterAPI from '@/api/letter/apis';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { ROUTER_PATHS } from '@/router';
 import { ReceptionLetterType } from '../hooks/useLetterTag';
+import LetterContent from '../components/LetterContent';
+import ReceptionPolaroid from '../components/ReceptionPolaroid';
 import style from './styles';
-
 interface ReceivedLetterProps {
   receptionLetter: ReceptionLetterType;
   onNext: () => void;
 }
 
 const ReceivedLetter = ({ receptionLetter, onNext }: ReceivedLetterProps) => {
+  const navigate = useNavigate();
   const tagList = receptionLetter.tagList;
+
+  const { mutateAsync: patchToss, isPending: isPending } = useMutation({
+    mutationFn: letterAPI.patchReceptionToss,
+  });
+
+  const handleTossLetter = async () => {
+    await patchToss(receptionLetter.letterId);
+    navigate(ROUTER_PATHS.ROOT);
+  };
 
   return (
     <LetterContent>
@@ -42,8 +56,8 @@ const ReceivedLetter = ({ receptionLetter, onNext }: ReceivedLetterProps) => {
         <ReceptionPolaroid />
       </LetterCard>
       <Navbar css={style.navbar}>
-        <Button variant="secondary" size="sm">
-          다시 흘려보내기
+        <Button variant="secondary" size="sm" onClick={handleTossLetter}>
+          {isPending ? <LoadingSpinner /> : '다시 흘려보내기'}
         </Button>
         <Tooltip
           side="top"

--- a/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
@@ -10,10 +10,11 @@ import { formatDate } from '@/utils/dateUtils';
 import letterAPI from '@/api/letter/apis';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { ROUTER_PATHS } from '@/router';
-import { ReceptionLetterType } from '../hooks/useLetterTag';
-import LetterContent from '../components/LetterContent';
 import ReceptionPolaroid from '../components/ReceptionPolaroid';
+import LetterContent from '../components/LetterContent';
+import { ReceptionLetterType } from '../hooks/useLetterTag';
 import style from './styles';
+
 interface ReceivedLetterProps {
   receptionLetter: ReceptionLetterType;
   onNext: () => void;

--- a/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
@@ -1,21 +1,22 @@
-import { css } from '@emotion/react';
 import LetterCard from '@/components/LetterCard';
 import Navbar from '@/components/Navbar';
 import Button from '@/components/Button';
 import Tooltip from '@/components/Tooltip';
-import textStyles from '@/styles/textStyles';
-import COLORS from '@/constants/colors';
 import LetterHeader from '@/components/LetterHeader';
 import Chip from '@/components/Chip';
-import ReceptionPolaroid from '../components/ReceptionPolaroid';
+import { formatDate } from '@/utils/dateUtils';
+import { ReceptionLetterType } from '../hooks/useLetterTag';
 import LetterContent from '../components/LetterContent';
+import ReceptionPolaroid from '../components/ReceptionPolaroid';
+import style from './styles';
 
 interface ReceivedLetterProps {
+  receptionLetter: ReceptionLetterType;
   onNext: () => void;
 }
 
-const ReceivedLetter = ({ onNext }: ReceivedLetterProps) => {
-  const tagList = ['20~24세', '모두에게', '기타'];
+const ReceivedLetter = ({ receptionLetter, onNext }: ReceivedLetterProps) => {
+  const tagList = receptionLetter.tagList;
 
   return (
     <LetterContent>
@@ -28,24 +29,15 @@ const ReceivedLetter = ({ onNext }: ReceivedLetterProps) => {
           ))}
         </div>
         <div css={style.text}>
-          <p>
-            여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대
-            부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘
-            다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대
-            있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는
-            동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴
-            그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오
-            사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을
-            견뎌 왔음에 감사하오 좋은 사람 만라겠소 이 맘만 가져가오
-          </p>
+          <p>{receptionLetter.content}</p>
         </div>
         <div css={style.date}>
-          <span>24년 02월 08일</span>
+          <span>{formatDate(new Date(receptionLetter.createdAt))}</span>
         </div>
         <LetterHeader
           title="From"
           titlePosition="right"
-          nickname="낯선 고양이"
+          nickname={receptionLetter.senderNickname}
         />
         <ReceptionPolaroid />
       </LetterCard>
@@ -67,27 +59,6 @@ const ReceivedLetter = ({ onNext }: ReceivedLetterProps) => {
       </Navbar>
     </LetterContent>
   );
-};
-
-const style = {
-  tag: css`
-    display: flex;
-    gap: 0.5rem;
-  `,
-  text: css`
-    height: 15rem;
-    ${textStyles.l1m};
-  `,
-  date: css`
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 3.5rem;
-    ${textStyles.c1r};
-    color: ${COLORS.gray2};
-  `,
-  navbar: css`
-    padding-inline: 0;
-  `,
 };
 
 export default ReceivedLetter;

--- a/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
@@ -5,14 +5,14 @@ import Navbar from '@/components/Navbar';
 import Button from '@/components/Button';
 import Tooltip from '@/components/Tooltip';
 import LetterHeader from '@/components/LetterHeader';
-import Chip from '@/components/Chip';
 import { formatDate } from '@/utils/dateUtils';
 import letterAPI from '@/api/letter/apis';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { ROUTER_PATHS } from '@/router';
-import ReceptionPolaroid from '../components/ReceptionPolaroid';
-import LetterContent from '../components/LetterContent';
+import TagList from '../components/TagList';
 import { ReceptionLetterType } from '../hooks/useLetterTag';
+import LetterContent from '../components/LetterContent';
+import ReceptionPolaroid from '../components/ReceptionPolaroid';
 import style from './styles';
 
 interface ReceivedLetterProps {
@@ -22,7 +22,6 @@ interface ReceivedLetterProps {
 
 const ReceivedLetter = ({ receptionLetter, onNext }: ReceivedLetterProps) => {
   const navigate = useNavigate();
-  const tagList = receptionLetter.tagList;
 
   const { mutateAsync: patchToss, isPending: isPending } = useMutation({
     mutationFn: letterAPI.patchReceptionToss,
@@ -36,13 +35,7 @@ const ReceivedLetter = ({ receptionLetter, onNext }: ReceivedLetterProps) => {
   return (
     <LetterContent>
       <LetterCard isOpen={true}>
-        <div css={style.tag}>
-          {tagList.map((tag) => (
-            <Chip key={tag} variant="filter">
-              {tag}
-            </Chip>
-          ))}
-        </div>
+        <TagList tags={receptionLetter.tagList} />
         <div css={style.text}>
           <p>{receptionLetter.content}</p>
         </div>

--- a/src/pages/LetterReceptionPage/ReceivedLetter/styles.ts
+++ b/src/pages/LetterReceptionPage/ReceivedLetter/styles.ts
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+import textStyles from '@/styles/textStyles';
+import COLORS from '@/constants/colors';
+
+const style = {
+  tag: css`
+    display: flex;
+    gap: 0.5rem;
+  `,
+  text: css`
+    height: 15rem;
+    ${textStyles.l1m};
+  `,
+  date: css`
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 3.5rem;
+    ${textStyles.c1r};
+    color: ${COLORS.gray2};
+  `,
+  navbar: css`
+    padding-inline: 0;
+  `,
+};
+
+export default style;

--- a/src/pages/LetterReceptionPage/ReceivedLetter/styles.ts
+++ b/src/pages/LetterReceptionPage/ReceivedLetter/styles.ts
@@ -3,10 +3,6 @@ import textStyles from '@/styles/textStyles';
 import COLORS from '@/constants/colors';
 
 const style = {
-  tag: css`
-    display: flex;
-    gap: 0.5rem;
-  `,
   text: css`
     height: 15rem;
     ${textStyles.l1m};

--- a/src/pages/LetterReceptionPage/ReplyToLetter/ReceivedAccordionLetter.tsx
+++ b/src/pages/LetterReceptionPage/ReplyToLetter/ReceivedAccordionLetter.tsx
@@ -1,0 +1,35 @@
+import LetterCard from '@/components/LetterCard';
+import LetterAccordion from '@/components/LetterAccordion';
+import useBoolean from '@/hooks/useBoolean';
+import ReceptionPolaroid from '../components/ReceptionPolaroid';
+import TagList from '../components/TagList';
+import { ReceptionLetterType } from '../hooks/useLetterTag';
+
+interface ReceivedAccordionLetterProps {
+  receptionLetter: ReceptionLetterType;
+}
+
+const ReceivedAccordionLetter = ({
+  receptionLetter,
+}: ReceivedAccordionLetterProps) => {
+  const { value: isOpen, toggle: accordionToggle } = useBoolean(false);
+
+  return (
+    <LetterCard css={{ marginBottom: '1rem' }}>
+      <TagList tags={receptionLetter.tagList} />
+      <LetterAccordion
+        isOpen={isOpen}
+        onToggle={accordionToggle}
+        id="1"
+        text={receptionLetter.content}
+        date={new Date(receptionLetter.createdAt)}
+        nickname={receptionLetter.senderNickname}
+        line={2}
+        type="send"
+      />
+      <ReceptionPolaroid />
+    </LetterCard>
+  );
+};
+
+export default ReceivedAccordionLetter;

--- a/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import z from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
 import LetterCard from '@/components/LetterCard';
 import LetterAccordion from '@/components/LetterAccordion';
 import Navbar from '@/components/Navbar';
@@ -24,11 +25,6 @@ interface ReplyToLetterProps {
   receptionLetter: ReceptionLetterType;
   onPrev: () => void;
 }
-
-// type Inputs = {
-//   replyContent: string;
-//   image: Blob;
-// };
 
 const L = letterWrite;
 
@@ -54,19 +50,26 @@ type Inputs = z.infer<typeof schema>;
 
 const ReplyToLetter = ({ receptionLetter, onPrev }: ReplyToLetterProps) => {
   const methods = useForm<Inputs>({
+    resolver: zodResolver(schema),
     defaultValues: {
       replyContent: '',
     },
   });
 
-  const { handleSubmit, register, watch, setValue } = methods;
+  const {
+    handleSubmit,
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = methods;
 
   const { value: isOpen, toggle: accordionToggle } = useBoolean(false);
 
   const tagList = receptionLetter.tagList;
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
+    const file = event.target.files;
     if (file) {
       setValue('image', file);
     }
@@ -119,7 +122,7 @@ const ReplyToLetter = ({ receptionLetter, onPrev }: ReplyToLetterProps) => {
             />
             <LetterLengthDate letterLength={watch('replyContent').length} />
             {watch('image') && (
-              <ReceptionPolaroid img={URL.createObjectURL(watch('image'))} />
+              <ReceptionPolaroid img={URL.createObjectURL(watch('image')[0])} />
             )}
           </LetterCard>
         </div>
@@ -138,6 +141,9 @@ const ReplyToLetter = ({ receptionLetter, onPrev }: ReplyToLetterProps) => {
           <ImageUploadButton onChangeImage={handleFileChange} />
         </Navbar>
       </form>
+      {/** 임시 에러 출력용 */}
+      {errors.replyContent && <p>{errors.replyContent.message}</p>}
+      {errors.image && <p>{errors.image.message?.toString()}</p>}
     </LetterContent>
   );
 };

--- a/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
@@ -1,34 +1,27 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
-import z from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import z from 'zod';
 import LetterCard from '@/components/LetterCard';
-import LetterAccordion from '@/components/LetterAccordion';
 import Navbar from '@/components/Navbar';
 import Button from '@/components/Button';
 import ImageUploadButton from '@/components/ImageUploadButton';
 import LetterTextarea from '@/components/LetterTextarea';
-import useBoolean from '@/hooks/useBoolean';
 import LetterLengthDate from '@/components/LetterLengthDate';
 import LetterHeader from '@/components/LetterHeader';
-import Chip from '@/components/Chip';
 import letterAPI from '@/api/letter/apis';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { letterWrite } from '@/constants/schemaLiteral';
-import { ReceptionLetterType } from '../hooks/useLetterTag';
-import ReceptionPolaroid from '../components/ReceptionPolaroid';
 import LetterContent from '../components/LetterContent';
+import ReceptionPolaroid from '../components/ReceptionPolaroid';
+import { ReceptionLetterType } from '../hooks/useLetterTag';
+import ReceivedAccordionLetter from './ReceivedAccordionLetter';
 import style from './styles';
-
-interface ReplyToLetterProps {
-  receptionLetter: ReceptionLetterType;
-  onPrev: () => void;
-}
 
 const L = letterWrite;
 
-const schema = z.object({
+const replySchema = z.object({
   replyContent: z
     .string()
     .min(L.content.min.value, { message: L.content.min.message })
@@ -46,11 +39,16 @@ const schema = z.object({
     ),
 });
 
-type Inputs = z.infer<typeof schema>;
+type replyInputs = z.infer<typeof replySchema>;
+
+interface ReplyToLetterProps {
+  receptionLetter: ReceptionLetterType;
+  onPrev: () => void;
+}
 
 const ReplyToLetter = ({ receptionLetter, onPrev }: ReplyToLetterProps) => {
-  const methods = useForm<Inputs>({
-    resolver: zodResolver(schema),
+  const methods = useForm<replyInputs>({
+    resolver: zodResolver(replySchema),
     defaultValues: {
       replyContent: '',
     },
@@ -64,10 +62,6 @@ const ReplyToLetter = ({ receptionLetter, onPrev }: ReplyToLetterProps) => {
     formState: { errors },
   } = methods;
 
-  const { value: isOpen, toggle: accordionToggle } = useBoolean(false);
-
-  const tagList = receptionLetter.tagList;
-
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files;
     if (file) {
@@ -79,7 +73,7 @@ const ReplyToLetter = ({ receptionLetter, onPrev }: ReplyToLetterProps) => {
     mutationFn: letterAPI.patchReceptionReply,
   });
 
-  const onSubmit = async (data: Inputs) => {
+  const onSubmit = async (data: replyInputs) => {
     const formData = new FormData();
     formData.append('replyContent', data.replyContent);
     formData.append('image', data.image);
@@ -90,26 +84,7 @@ const ReplyToLetter = ({ receptionLetter, onPrev }: ReplyToLetterProps) => {
     <LetterContent isBlock={true}>
       <form onSubmit={handleSubmit(onSubmit)}>
         <div css={style.letter}>
-          <LetterCard css={{ marginBottom: '1rem' }}>
-            <div css={style.tag}>
-              {tagList.map((tag) => (
-                <Chip key={tag} variant="filter">
-                  {tag}
-                </Chip>
-              ))}
-            </div>
-            <LetterAccordion
-              isOpen={isOpen}
-              onToggle={accordionToggle}
-              id="1"
-              text={receptionLetter.content}
-              date={new Date(receptionLetter.createdAt)}
-              nickname={receptionLetter.senderNickname}
-              line={2}
-              type="send"
-            />
-            <ReceptionPolaroid />
-          </LetterCard>
+          <ReceivedAccordionLetter receptionLetter={receptionLetter} />
           <LetterCard isOpen={true}>
             <LetterHeader
               title="To"

--- a/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
@@ -9,9 +9,9 @@ import useBoolean from '@/hooks/useBoolean';
 import LetterLengthDate from '@/components/LetterLengthDate';
 import LetterHeader from '@/components/LetterHeader';
 import Chip from '@/components/Chip';
-import { ReceptionLetterType } from '../hooks/useLetterTag';
-import ReceptionPolaroid from '../components/ReceptionPolaroid';
 import LetterContent from '../components/LetterContent';
+import ReceptionPolaroid from '../components/ReceptionPolaroid';
+import { ReceptionLetterType } from '../hooks/useLetterTag';
 import style from './styles';
 interface ReplyToLetterProps {
   receptionLetter: ReceptionLetterType;

--- a/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { useForm } from 'react-hook-form';
+import { useMutation } from '@tanstack/react-query';
+import z from 'zod';
 import LetterCard from '@/components/LetterCard';
 import LetterAccordion from '@/components/LetterAccordion';
 import Navbar from '@/components/Navbar';
@@ -9,71 +12,132 @@ import useBoolean from '@/hooks/useBoolean';
 import LetterLengthDate from '@/components/LetterLengthDate';
 import LetterHeader from '@/components/LetterHeader';
 import Chip from '@/components/Chip';
-import LetterContent from '../components/LetterContent';
-import ReceptionPolaroid from '../components/ReceptionPolaroid';
+import letterAPI from '@/api/letter/apis';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { letterWrite } from '@/constants/schemaLiteral';
 import { ReceptionLetterType } from '../hooks/useLetterTag';
+import ReceptionPolaroid from '../components/ReceptionPolaroid';
+import LetterContent from '../components/LetterContent';
 import style from './styles';
+
 interface ReplyToLetterProps {
   receptionLetter: ReceptionLetterType;
   onPrev: () => void;
 }
 
+// type Inputs = {
+//   replyContent: string;
+//   image: Blob;
+// };
+
+const L = letterWrite;
+
+const schema = z.object({
+  replyContent: z
+    .string()
+    .min(L.content.min.value, { message: L.content.min.message })
+    .max(L.content.max.value, { message: L.content.max.message }),
+  image: z
+    .any()
+    .optional()
+    .refine(
+      (files) => !files || files[0].size <= L.image.maxFileSize.value,
+      L.image.maxFileSize.message,
+    )
+    .refine(
+      (files) => !files || L.image.acceptType.list.includes(files[0].type),
+      L.image.acceptType.message,
+    ),
+});
+
+type Inputs = z.infer<typeof schema>;
+
 const ReplyToLetter = ({ receptionLetter, onPrev }: ReplyToLetterProps) => {
+  const methods = useForm<Inputs>({
+    defaultValues: {
+      replyContent: '',
+    },
+  });
+
+  const { handleSubmit, register, watch, setValue } = methods;
+
   const { value: isOpen, toggle: accordionToggle } = useBoolean(false);
 
   const tagList = receptionLetter.tagList;
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    console.log(file);
+    if (file) {
+      setValue('image', file);
+    }
+  };
+
+  const { mutateAsync: patchReply, isPending: isPending } = useMutation({
+    mutationFn: letterAPI.patchReceptionReply,
+  });
+
+  const onSubmit = async (data: Inputs) => {
+    const formData = new FormData();
+    formData.append('replyContent', data.replyContent);
+    formData.append('image', data.image);
+    await patchReply({ letterId: receptionLetter.letterId, body: formData });
   };
 
   return (
     <LetterContent isBlock={true}>
-      <div css={style.letter}>
-        <LetterCard css={{ marginBottom: '1rem' }}>
-          <div css={style.tag}>
-            {tagList.map((tag) => (
-              <Chip key={tag} variant="filter">
-                {tag}
-              </Chip>
-            ))}
-          </div>
-          <LetterAccordion
-            isOpen={isOpen}
-            onToggle={accordionToggle}
-            id="1"
-            text={receptionLetter.content}
-            date={new Date(receptionLetter.createdAt)}
-            nickname={receptionLetter.senderNickname}
-            line={2}
-            type="send"
-          />
-          <ReceptionPolaroid />
-        </LetterCard>
-        <LetterCard isOpen={true}>
-          <LetterHeader title="To" nickname={receptionLetter.senderNickname} />
-          <LetterTextarea
-            name="content"
-            placeholder="하고싶은 이야기를 답장으로 적어보세요."
-          />
-          <LetterLengthDate letterLength={0} />
-        </LetterCard>
-      </div>
-      <Navbar css={style.navbar}>
-        <Button
-          type="button"
-          variant="semi-transparent-unaccent"
-          size="sm"
-          onClick={onPrev}
-        >
-          다시 흘러보내기
-        </Button>
-        <Button type="submit" variant="semi-transparent" size="sm">
-          답장 보내기
-        </Button>
-        <ImageUploadButton onChangeImage={handleFileChange} />
-      </Navbar>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div css={style.letter}>
+          <LetterCard css={{ marginBottom: '1rem' }}>
+            <div css={style.tag}>
+              {tagList.map((tag) => (
+                <Chip key={tag} variant="filter">
+                  {tag}
+                </Chip>
+              ))}
+            </div>
+            <LetterAccordion
+              isOpen={isOpen}
+              onToggle={accordionToggle}
+              id="1"
+              text={receptionLetter.content}
+              date={new Date(receptionLetter.createdAt)}
+              nickname={receptionLetter.senderNickname}
+              line={2}
+              type="send"
+            />
+            <ReceptionPolaroid />
+          </LetterCard>
+          <LetterCard isOpen={true}>
+            <LetterHeader
+              title="To"
+              nickname={receptionLetter.senderNickname}
+            />
+            <LetterTextarea
+              {...register('replyContent')}
+              name="replyContent"
+              placeholder="하고싶은 이야기를 답장으로 적어보세요."
+            />
+            <LetterLengthDate letterLength={watch('replyContent').length} />
+            {watch('image') && (
+              <ReceptionPolaroid img={URL.createObjectURL(watch('image'))} />
+            )}
+          </LetterCard>
+        </div>
+        <Navbar css={style.navbar}>
+          <Button
+            type="button"
+            variant="semi-transparent-unaccent"
+            size="sm"
+            onClick={onPrev}
+          >
+            취소
+          </Button>
+          <Button type="submit" variant="semi-transparent" size="sm">
+            {isPending ? <LoadingSpinner /> : '답장 보내기'}
+          </Button>
+          <ImageUploadButton onChangeImage={handleFileChange} />
+        </Navbar>
+      </form>
     </LetterContent>
   );
 };

--- a/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
@@ -1,27 +1,27 @@
 import React from 'react';
-import { css } from '@emotion/react';
 import LetterCard from '@/components/LetterCard';
 import LetterAccordion from '@/components/LetterAccordion';
 import Navbar from '@/components/Navbar';
 import Button from '@/components/Button';
 import ImageUploadButton from '@/components/ImageUploadButton';
 import LetterTextarea from '@/components/LetterTextarea';
-import textStyles from '@/styles/textStyles';
 import useBoolean from '@/hooks/useBoolean';
 import LetterLengthDate from '@/components/LetterLengthDate';
 import LetterHeader from '@/components/LetterHeader';
 import Chip from '@/components/Chip';
-import LetterContent from '../components/LetterContent';
+import { ReceptionLetterType } from '../hooks/useLetterTag';
 import ReceptionPolaroid from '../components/ReceptionPolaroid';
-
+import LetterContent from '../components/LetterContent';
+import style from './styles';
 interface ReplyToLetterProps {
+  receptionLetter: ReceptionLetterType;
   onPrev: () => void;
 }
 
-const ReplyToLetter = ({ onPrev }: ReplyToLetterProps) => {
+const ReplyToLetter = ({ receptionLetter, onPrev }: ReplyToLetterProps) => {
   const { value: isOpen, toggle: accordionToggle } = useBoolean(false);
 
-  const tagList = ['20~24세', '모두에게', '기타'];
+  const tagList = receptionLetter.tagList;
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -43,16 +43,16 @@ const ReplyToLetter = ({ onPrev }: ReplyToLetterProps) => {
             isOpen={isOpen}
             onToggle={accordionToggle}
             id="1"
-            text="여기까지가 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오여기까지가 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋"
-            date={new Date()}
-            nickname="낯선 고양이"
+            text={receptionLetter.content}
+            date={new Date(receptionLetter.createdAt)}
+            nickname={receptionLetter.senderNickname}
             line={2}
             type="send"
           />
           <ReceptionPolaroid />
         </LetterCard>
         <LetterCard isOpen={true}>
-          <LetterHeader title="To" nickname="낯선 고양이" />
+          <LetterHeader title="To" nickname={receptionLetter.senderNickname} />
           <LetterTextarea
             name="content"
             placeholder="하고싶은 이야기를 답장으로 적어보세요."
@@ -76,27 +76,6 @@ const ReplyToLetter = ({ onPrev }: ReplyToLetterProps) => {
       </Navbar>
     </LetterContent>
   );
-};
-
-const style = {
-  tag: css`
-    display: flex;
-    gap: 0.5rem;
-  `,
-  text: css`
-    ${textStyles.l1m};
-  `,
-  letter: css`
-    overflow-y: auto;
-    max-height: calc(100dvh - 60px - 80px - 16px);
-  `,
-  navbar: css`
-    position: fixed;
-    bottom: 0;
-    width: 96vw;
-    max-width: 580px;
-    padding-inline: 0;
-  `,
 };
 
 export default ReplyToLetter;

--- a/src/pages/LetterReceptionPage/ReplyToLetter/styles.ts
+++ b/src/pages/LetterReceptionPage/ReplyToLetter/styles.ts
@@ -2,10 +2,6 @@ import { css } from '@emotion/react';
 import textStyles from '@/styles/textStyles';
 
 const style = {
-  tag: css`
-    display: flex;
-    gap: 0.5rem;
-  `,
   text: css`
     ${textStyles.l1m};
   `,

--- a/src/pages/LetterReceptionPage/ReplyToLetter/styles.ts
+++ b/src/pages/LetterReceptionPage/ReplyToLetter/styles.ts
@@ -1,0 +1,25 @@
+import { css } from '@emotion/react';
+import textStyles from '@/styles/textStyles';
+
+const style = {
+  tag: css`
+    display: flex;
+    gap: 0.5rem;
+  `,
+  text: css`
+    ${textStyles.l1m};
+  `,
+  letter: css`
+    overflow-y: auto;
+    max-height: calc(100dvh - 60px - 80px - 16px);
+  `,
+  navbar: css`
+    position: fixed;
+    bottom: 0;
+    width: 96vw;
+    max-width: 580px;
+    padding-inline: 0;
+  `,
+};
+
+export default style;

--- a/src/pages/LetterReceptionPage/components/ReceptionHeader.tsx
+++ b/src/pages/LetterReceptionPage/components/ReceptionHeader.tsx
@@ -16,7 +16,12 @@ const ReceptionHeader = ({ onClickPrev }: ReceptionHeaderProps) => {
       css={style.header}
       leftContent={
         <>
-          <CaretLeft strokeWidth={2.5} color="white" onClick={onClickPrev} />
+          <CaretLeft
+            css={style.icon}
+            strokeWidth={2.5}
+            color="white"
+            onClick={onClickPrev}
+          />
           <Chip variant="primary">
             <HourGlass height={16} color={COLORS.primary} />
             <span css={{ color: COLORS.primary }}>00:00:00</span>
@@ -40,6 +45,9 @@ const style = {
   leftHeader: css`
     display: flex;
     gap: 0.5rem;
+  `,
+  icon: css`
+    cursor: pointer;
   `,
 };
 

--- a/src/pages/LetterReceptionPage/components/TagList.tsx
+++ b/src/pages/LetterReceptionPage/components/TagList.tsx
@@ -1,0 +1,27 @@
+import { css } from '@emotion/react';
+import Chip from '@/components/Chip';
+
+interface tagsProps {
+  tags: string[];
+}
+
+const TagList = ({ tags }: tagsProps) => {
+  return (
+    <div css={style.tag}>
+      {tags.map((tag) => (
+        <Chip key={tag} variant="filter">
+          {tag}
+        </Chip>
+      ))}
+    </div>
+  );
+};
+
+export default TagList;
+
+const style = {
+  tag: css`
+    display: flex;
+    gap: 0.5rem;
+  `,
+};

--- a/src/pages/LetterReceptionPage/hooks/useLetterTag.ts
+++ b/src/pages/LetterReceptionPage/hooks/useLetterTag.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import letterOptions from '@/api/letter/queryOptions';
+import { WORRY_DICT } from '@/constants/users';
+import { Reception } from '@/types/letter';
+
+interface ReceptionLetterType extends Reception {
+  tagList: string[];
+}
+
+const useLetterTag = (letterId: string) => {
+  const { data } = useQuery({
+    ...letterOptions.singleReception(Number(letterId)),
+  });
+
+  /**
+   * TODO: 나이, 성별 값 배열에 넣기
+   */
+  const tagList = data ? [WORRY_DICT[data.worryType]] : [];
+  const letter: ReceptionLetterType = { ...data!, tagList };
+
+  return { letter };
+};
+
+export type { ReceptionLetterType };
+
+export default useLetterTag;

--- a/src/pages/LetterReceptionPage/hooks/useLetterTag.ts
+++ b/src/pages/LetterReceptionPage/hooks/useLetterTag.ts
@@ -17,7 +17,7 @@ const useLetterTag = (letterId: number) => {
   }
 
   /**
-   * TODO: 나이, 성별 값 배열에 넣기
+   * TODO: 나이, 성별 태그값 배열에 넣기
    */
   const tagList = data ? [WORRY_DICT[data.worryType]] : [];
   const letter: ReceptionLetterType = { ...data!, tagList };

--- a/src/pages/LetterReceptionPage/hooks/useLetterTag.ts
+++ b/src/pages/LetterReceptionPage/hooks/useLetterTag.ts
@@ -2,15 +2,19 @@ import { useQuery } from '@tanstack/react-query';
 import letterOptions from '@/api/letter/queryOptions';
 import { WORRY_DICT } from '@/constants/users';
 import { Reception } from '@/types/letter';
-
 interface ReceptionLetterType extends Reception {
   tagList: string[];
 }
 
-const useLetterTag = (letterId: string) => {
-  const { data } = useQuery({
-    ...letterOptions.singleReception(Number(letterId)),
+const useLetterTag = (letterId: number) => {
+  const { data, error } = useQuery({
+    ...letterOptions.singleReception(letterId),
   });
+
+  if (error) {
+    /** 에러 나면 ???  */
+    console.error(error.message);
+  }
 
   /**
    * TODO: 나이, 성별 값 배열에 넣기

--- a/src/pages/LetterReceptionPage/intex.tsx
+++ b/src/pages/LetterReceptionPage/intex.tsx
@@ -1,11 +1,11 @@
 import { useNavigate, useParams } from 'react-router-dom';
-import { css } from '@emotion/react';
-import createFunnel from '@/components/Funnel/createFunnel';
 import { ROUTER_PATHS } from '@/router';
+import createFunnel from '@/components/Funnel/createFunnel';
 import useLetterTag from './hooks/useLetterTag';
 import ReceivedLetter from './ReceivedLetter';
 import ReplyToLetter from './ReplyToLetter';
 import ReceptionHeader from './components/ReceptionHeader';
+import style from './styles';
 
 const { Funnel, Step, useFunnel } = createFunnel([
   'ReceivedLetter',
@@ -13,16 +13,12 @@ const { Funnel, Step, useFunnel } = createFunnel([
 ] as const);
 
 const LetterReceptionPage = () => {
+  const navigate = useNavigate();
   const { letterId } = useParams();
 
-  /**
-   * letterId 가 유효하지 않을때에는?
-   * letterId 가 숫자가 아닌 값일 땐 "존재하지 않는 페이지 입니다"? 보여주기?
-   */
-  const { letter } = useLetterTag(letterId || '1');
+  const { letter } = useLetterTag(Number(letterId));
 
   const { step, setStep, toPrev } = useFunnel();
-  const navigate = useNavigate();
 
   return (
     <div css={style.container}>
@@ -47,15 +43,6 @@ const LetterReceptionPage = () => {
       </Funnel>
     </div>
   );
-};
-
-const style = {
-  container: css`
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    height: 100%;
-  `,
 };
 
 export default LetterReceptionPage;

--- a/src/pages/LetterReceptionPage/intex.tsx
+++ b/src/pages/LetterReceptionPage/intex.tsx
@@ -1,7 +1,8 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { css } from '@emotion/react';
 import createFunnel from '@/components/Funnel/createFunnel';
 import { ROUTER_PATHS } from '@/router';
+import useLetterTag from './hooks/useLetterTag';
 import ReceivedLetter from './ReceivedLetter';
 import ReplyToLetter from './ReplyToLetter';
 import ReceptionHeader from './components/ReceptionHeader';
@@ -12,6 +13,14 @@ const { Funnel, Step, useFunnel } = createFunnel([
 ] as const);
 
 const LetterReceptionPage = () => {
+  const { letterId } = useParams();
+
+  /**
+   * letterId 가 유효하지 않을때에는?
+   * letterId 가 숫자가 아닌 값일 땐 "존재하지 않는 페이지 입니다"? 보여주기?
+   */
+  const { letter } = useLetterTag(letterId || '1');
+
   const { step, setStep, toPrev } = useFunnel();
   const navigate = useNavigate();
 
@@ -24,10 +33,16 @@ const LetterReceptionPage = () => {
       />
       <Funnel step={step}>
         <Step name="ReceivedLetter">
-          <ReceivedLetter onNext={() => setStep('ReplyToLetter')} />
+          <ReceivedLetter
+            receptionLetter={letter}
+            onNext={() => setStep('ReplyToLetter')}
+          />
         </Step>
         <Step name="ReplyToLetter">
-          <ReplyToLetter onPrev={() => setStep('ReceivedLetter')} />
+          <ReplyToLetter
+            receptionLetter={letter}
+            onPrev={() => setStep('ReceivedLetter')}
+          />
         </Step>
       </Funnel>
     </div>

--- a/src/pages/LetterReceptionPage/styles.ts
+++ b/src/pages/LetterReceptionPage/styles.ts
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+const style = {
+  container: css`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+  `,
+};
+
+export default style;

--- a/src/pages/LetterWritePage/components/LetterPaper.tsx
+++ b/src/pages/LetterWritePage/components/LetterPaper.tsx
@@ -1,6 +1,6 @@
 import { useFormContext } from 'react-hook-form';
-import LetterCard from '@/components/LetterCard';
 import LetterLengthDate from '@/components/LetterLengthDate';
+import LetterCard from '@/components/LetterCard';
 import { type Inputs } from '..';
 import { BottomSheetProps } from './LetterWriteContent';
 import { LetterReceiverContainer, LetterContent, PolaroidImage } from '.';

--- a/src/pages/LetterWritePage/index.tsx
+++ b/src/pages/LetterWritePage/index.tsx
@@ -10,8 +10,8 @@ import { letterWrite } from '@/constants/schemaLiteral';
 import { EQUAL_GENDER_DICT, type Worry } from '@/constants/letters';
 import { Letter } from '@/types/letter';
 import letterAPI from '@/api/letter/apis';
-import style from './styles';
 import { LetterWriteContent, LetterWriteBottom } from './components';
+import style from './styles';
 
 const L = letterWrite;
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -61,6 +61,10 @@ const router = createBrowserRouter([
         path: ROUTER_PATHS.LETTER_RECEPTION(':letterId'),
         element: <LetterReceptionPage />,
       },
+      {
+        path: '*',
+        element: <div>잘못된 경로입니다.</div>,
+      },
     ],
   },
 ]);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,7 +17,7 @@ const ROUTER_PATHS = {
   SIGNIN_REDIRECT_KAKAO: '/signin/redirect/kakao',
   ONBOARDING: '/onboarding',
   LETTER_WRITE: '/write',
-  LETTER_RECEPTION: '/reception',
+  LETTER_RECEPTION: (letterId: string) => `/reception/${letterId}`,
 } as const;
 
 const router = createBrowserRouter([
@@ -58,7 +58,7 @@ const router = createBrowserRouter([
         element: <LetterWritePage />,
       },
       {
-        path: ROUTER_PATHS.LETTER_RECEPTION,
+        path: ROUTER_PATHS.LETTER_RECEPTION(':letterId'),
         element: <LetterReceptionPage />,
       },
     ],

--- a/src/types/letter.ts
+++ b/src/types/letter.ts
@@ -8,3 +8,12 @@ export type Letter = {
   worryType: Worry;
   image: File;
 };
+
+export type Reception = {
+  createdAt: string;
+  letterId: number;
+  senderNickname: string;
+  receiverNickname: string;
+  content: string;
+  worryType: Worry;
+};


### PR DESCRIPTION
## 🧩 이슈 번호

- close #92 

## ✅ 작업 사항

### 보낸 편지 단건 조회

현재 경로에서 `letterId` 파라미터를 사용해서 `useLetterTag` 훅을 호출하도록 했습니다.

```tsx
const { letterId } = useParams();
const { letter } = useLetterTag(Number(letterId));
```

`useLetterTag` 훅에서는 태그 값들을 배열로 만들어야 하는데 아직 나이, 성별은 API 문서에는 없어 고민종류만 tagList 에 넣었습니다.
(나중에 나이, 성별, 사진 더 받아와야 함)

```tsx
const tagList = data ? [WORRY_DICT[data.worryType]] : [];
```

`ReceptionHeader` 컴포넌트가 처음에 렌더링 될 때 createTime 값이 undefined 라서 삼항연산자를 사용했습니다. 그런데 추후에 GET 요청이 Loading 상태일 때 LoadingComponent 를 렌더링 하면 이런식으로 표현 안해도 될 것 같습니다.

```tsx
  const expiredTime = useMemo(() => {
    return createTime
      ? formatTimechipDate(
          new Date(),
          new Date(new Date(createTime).getTime() + 48 * 60 * 60 * 1000),
        )
      : '00h';
  }, [createTime]);
```

### 받은 편지 토스

받은 편지 토스 후 메인 페이지로 가도록 했습니다.

```tsx
  const { mutateAsync: patchToss, isPending: isPending } = useMutation({
    mutationFn: letterAPI.patchReceptionToss,
  });

  const handleTossLetter = async () => {
    await patchToss(receptionLetter.letterId);
    navigate(ROUTER_PATHS.ROOT);
  };

```

### 받은 편지 답장

API 문서에 편지 보내는 부분이 formData 형식으로 보내달라 하셔서 (편지 보내는 부분도 수정할 예정)

<img width="500" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/79c482c2-c79a-4f19-a488-7b43765ba71e">


흘러온 편지 페이지도 추후에 이미지도 보내야 하기 때문에 json 이 아니라 `formData` 형식으로 보냈습니다.

```tsx
  patchReceptionReply: async ({
    letterId,
    body,
  }: {
    letterId: number;
    body: FormData;
  }) => {
    const { data } = await authInstance.patch(
      `api/letter/reception/reply/${letterId}`,
      body,
      {
        headers: {
          'Content-Type': 'multipart/form-data',
        },
      },
    );
    return data;
  },
```


## 👩‍💻 공유 포인트 및 논의 사항
