### PR TITLE
🔨 refactor: 편지쓰기 페이지 formData 형식으로 변경

### DIFF
--- a/src/api/letter/apis.ts
+++ b/src/api/letter/apis.ts
@@ -1,4 +1,3 @@
-import { Letter } from '@/types/letter';
 import { Worry } from '@/constants/users';
 import { baseInstance } from '../instance';
 
@@ -39,8 +38,12 @@ const letterAPI = {
   },
 
   /** 편지 작성 */
-  postLetter: async (letter: Letter) => {
-    const { data } = await baseInstance.post('/api/letter', letter);
+  postLetter: async (letter: FormData) => {
+    const { data } = await baseInstance.post('/api/letter', letter, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
     return data;
   },
 };

--- a/src/pages/LetterWritePage/components/LetterPaper.tsx
+++ b/src/pages/LetterWritePage/components/LetterPaper.tsx
@@ -1,6 +1,6 @@
 import { useFormContext } from 'react-hook-form';
-import LetterCard from '@/components/LetterCard';
 import LetterLengthDate from '@/components/LetterLengthDate';
+import LetterCard from '@/components/LetterCard';
 import { type Inputs } from '..';
 import { BottomSheetProps } from './LetterWriteContent';
 import { LetterReceiverContainer, LetterContent, PolaroidImage } from '.';

--- a/src/pages/LetterWritePage/components/LetterWriteBottom.tsx
+++ b/src/pages/LetterWritePage/components/LetterWriteBottom.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import Navbar from '@/components/Navbar';
 import Button from '@/components/Button';
 import { ROUTER_PATHS } from '@/router';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import { ImageSelect } from '.';
 
 interface LetterWriteBottomProps {
@@ -23,8 +24,7 @@ const LetterWriteBottom = ({ isPosting }: LetterWriteBottomProps) => {
         취소
       </Button>
       <Button disabled={isPosting} type="submit" variant="primary" size="sm">
-        {/** isPosting 가 true 일 때 로딩스피너 보여줄 예정  */}
-        보내기
+        {isPosting ? <LoadingSpinner /> : '보내기'}
       </Button>
       <ImageSelect />
     </Navbar>

--- a/src/pages/LetterWritePage/index.tsx
+++ b/src/pages/LetterWritePage/index.tsx
@@ -8,10 +8,9 @@ import { CaretLeft } from '@/assets/icons';
 import Header from '@/components/Header';
 import { letterWrite } from '@/constants/schemaLiteral';
 import { EQUAL_GENDER_DICT, type Worry } from '@/constants/letters';
-import { Letter } from '@/types/letter';
 import letterAPI from '@/api/letter/apis';
-import style from './styles';
 import { LetterWriteContent, LetterWriteBottom } from './components';
+import style from './styles';
 
 const L = letterWrite;
 
@@ -63,15 +62,18 @@ const LetterWritePage = () => {
   });
 
   const onSubmit = async (data: Inputs) => {
-    const letterData: Letter = {
-      content: data.content,
-      equalGender: EQUAL_GENDER_DICT[1] === data.gender,
-      ageRangeStart: data.age[0],
-      ageRangeEnd: data.age[1],
-      worryType: data.worryType as Worry,
-      image: data.image?.[0],
-    };
-    await postLetter(letterData);
+    const formData = new FormData();
+    formData.append('content', data.content);
+    formData.append(
+      'equalGender',
+      EQUAL_GENDER_DICT[1] === data.gender ? 'true' : 'false',
+    );
+    formData.append('ageRangeStart', data.age[0].toString());
+    formData.append('ageRangeEnd', data.age[1].toString());
+    formData.append('worryType', data.worryType as Worry);
+    formData.append('image', data.image?.[0]);
+
+    await postLetter(formData);
   };
 
   return (

--- a/src/pages/LetterWritePage/styles.ts
+++ b/src/pages/LetterWritePage/styles.ts
@@ -6,7 +6,6 @@ const style = {
     flex-direction: column;
     width: 100%;
     height: 100%;
-    backdrop-filter: blur(20px);
   `,
   header: css`
     height: 2.5rem;


### PR DESCRIPTION
## 🧩 이슈 번호

- close #98 

## ✅ 작업 사항

편지쓰기 페이지에서 json 이 아닌 formData 형식으로 변경했습니다.

```tsx
  const onSubmit = async (data: Inputs) => {
    const formData = new FormData();
    formData.append('content', data.content);
    formData.append(
      'equalGender',
      EQUAL_GENDER_DICT[1] === data.gender ? 'true' : 'false',
    );
    formData.append('ageRangeStart', data.age[0].toString());
    formData.append('ageRangeEnd', data.age[1].toString());
    formData.append('worryType', data.worryType as Worry);
    formData.append('image', data.image?.[0]);

    await postLetter(formData);
  };
```

각각 console 로 찍어보면 데이터가 잘 들어간 것을 확인할 수 있고

<img width="444" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/5c0c8b0c-3953-4185-8d44-ebe2abec3af1">

요청 결과도 잘 들어간 것 같습니다.

<img width="455" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/fdbf9ccc-cf1f-4268-a625-7ff09a1da503">


## 👩‍💻 공유 포인트 및 논의 사항
