### PR TITLE
✨ feat: 마이 페이지의 전반적인 API 호출 로직 구현

### DIFF
--- a/src/api/member/apis.ts
+++ b/src/api/member/apis.ts
@@ -1,9 +1,4 @@
-import {
-  type Worry,
-  type Gender,
-  type Role,
-  type Nickname,
-} from '@/constants/users';
+import { type Worry, type Gender, type Role } from '@/constants/users';
 import { authInstance } from '../instance';
 
 const memberAPI = {
@@ -22,7 +17,7 @@ const memberAPI = {
   },
 
   /** 닉네임 수정 */
-  patchNickname: async (params: { nickname: Nickname }) => {
+  patchNickname: async (params: { nickname: string }) => {
     const { data } = await authInstance.patch('/api/member/nickname', {
       params,
     });

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -14,7 +14,7 @@ const Chip = ({ variant = 'primary', children, ...props }: ChipProps) => {
     <button
       {...props}
       type="button"
-      disabled={variant === 'primary-disabled'}
+      disabled={variant === 'primary-disabled' || variant === 'form-disabled'}
       css={style.chip(variant)}
     >
       {children}

--- a/src/components/Chip/styles.ts
+++ b/src/components/Chip/styles.ts
@@ -9,11 +9,14 @@ export type VariantType =
   | 'bottle-tag-bubble'
   | 'filter'
   | 'form'
-  | 'form-selected';
+  | 'form-selected'
+  | 'form-disabled';
 
 const styles = {
   chip: (variant: VariantType) => css`
-    cursor: ${variant === 'primary-disabled' ? 'not-allowed' : 'pointer'};
+    cursor: ${variant === 'primary-disabled' || variant === 'form-disabled'
+      ? 'not-allowed'
+      : 'pointer'};
     ${variants[variant]}
   `,
 };
@@ -117,6 +120,11 @@ const variants = {
     ${formChipStyles};
     border: 1px solid #2f80ed;
     background: rgb(47 128 237 / 0.2);
+  `,
+  'form-disabled': css`
+    ${formChipStyles};
+    border: 1px solid ${COLORS.gray5};
+    color: ${COLORS.gray4};
   `,
 };
 

--- a/src/components/GenderCard/index.stories.tsx
+++ b/src/components/GenderCard/index.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { css } from '@emotion/react';
-import { type Gender } from '@/constants/users';
+import { GENDER_DICT, type Gender } from '@/constants/users';
 import GenderCard from './';
 
 const meta = {
@@ -40,23 +40,31 @@ export const Primary_Variant: Story = {
     const Component = () => {
       const [gender, setGender] = useState<Gender>();
 
+      const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value as Gender;
+
+        if (value in GENDER_DICT) {
+          setGender(value);
+        }
+      };
+
       return (
         <section
           css={[styles.genderSection, css({ backgroundColor: '#3EAFFF' })]}
         >
           <GenderCard
-            variant="primary"
-            name="gender"
             value="MALE"
+            name="gender"
+            variant="primary"
             selectedValue={gender}
-            onClick={() => setGender('MALE')}
+            onChange={handleSelect}
           />
           <GenderCard
-            variant="primary"
-            name="gender"
             value="FEMALE"
+            name="gender"
+            variant="primary"
             selectedValue={gender}
-            onClick={() => setGender('FEMALE')}
+            onChange={handleSelect}
           />
         </section>
       );
@@ -72,21 +80,29 @@ export const Secondary_Variant: Story = {
     const Component = () => {
       const [gender, setGender] = useState<Gender>();
 
+      const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value as Gender;
+
+        if (value in GENDER_DICT) {
+          setGender(value);
+        }
+      };
+
       return (
         <section css={styles.genderSection}>
           <GenderCard
-            variant="secondary"
-            name="gender"
             value="MALE"
+            name="gender"
+            variant="secondary"
             selectedValue={gender}
-            onClick={() => setGender('MALE')}
+            onChange={handleSelect}
           />
           <GenderCard
-            variant="secondary"
-            name="gender"
             value="FEMALE"
+            name="gender"
+            variant="secondary"
             selectedValue={gender}
-            onClick={() => setGender('FEMALE')}
+            onChange={handleSelect}
           />
         </section>
       );

--- a/src/components/LoadingSpinner/index.tsx
+++ b/src/components/LoadingSpinner/index.tsx
@@ -14,8 +14,9 @@ const LoadingSpinner = ({
   size = '1rem',
   weight = '2px',
   color = 'currentColor',
+  ...props
 }: LoadingSpinnerProps) => {
-  return <div css={styles.spinner(size, weight, color)} />;
+  return <div css={styles.spinner(size, weight, color)} {...props} />;
 };
 
 export default LoadingSpinner;

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -22,7 +22,7 @@ const memberHandler = [
       id: 7,
       email: 'tnlswodnjs99@naver.com',
       nickname: '낯선 거북이',
-      worryTypes: [],
+      worryTypes: ['COURSE', 'STUDY', 'RELATIONSHIP'],
       gender: 'MALE',
       age: 40,
       role: 'USER',

--- a/src/pages/MyPage/components/GenderBottomSheet.tsx
+++ b/src/pages/MyPage/components/GenderBottomSheet.tsx
@@ -1,20 +1,64 @@
+import { useState } from 'react';
 import { css } from '@emotion/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import BottomSheet from '@/components/BottomSheet';
 import useBoolean from '@/hooks/useBoolean';
 import Button from '@/components/Button';
 import GenderCard from '@/components/GenderCard';
+import { GENDER_DICT, type Gender } from '@/constants/users';
+import memberOptions from '@/api/member/queryOptions';
+import memberAPI from '@/api/member/apis';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import { bottomSheetStyles } from '../style';
 
 interface GenderBottomSheetProps extends ReturnType<typeof useBoolean> {}
 
 const GenderBottomSheet = ({ value, on, off }: GenderBottomSheetProps) => {
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: memberAPI.patchGender,
+  });
+  const queryClient = useQueryClient();
+
+  const [gender, setGender] = useState<Gender>();
+
+  const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value as Gender;
+
+    if (value in GENDER_DICT) {
+      setGender(value);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!gender) {
+      return;
+    }
+
+    await mutateAsync({ gender });
+    queryClient.invalidateQueries({
+      queryKey: memberOptions.detail().queryKey,
+    });
+  };
+
   return (
     <BottomSheet open={value} onOpen={on} onClose={off}>
       <section css={bottomSheetStyles.mainSection}>
         <h2 css={bottomSheetStyles.title}>어떤 성별로 변경하시겠어요?</h2>
         <section css={styles.genderSection}>
-          <GenderCard variant="secondary" value="MALE" />
-          <GenderCard variant="secondary" value="FEMALE" />
+          <GenderCard
+            value="MALE"
+            variant="secondary"
+            name="gender"
+            selectedValue={gender}
+            onChange={handleSelect}
+          />
+          <GenderCard
+            value="FEMALE"
+            variant="secondary"
+            name="gender"
+            selectedValue={gender}
+            onChange={handleSelect}
+          />
         </section>
         <p css={bottomSheetStyles.description}>
           성별은 한 번만 수정할 수 있어요
@@ -24,8 +68,20 @@ const GenderBottomSheet = ({ value, on, off }: GenderBottomSheetProps) => {
         <Button variant="cancel" rounded="none" size="sm" onClick={off}>
           닫기
         </Button>
-        <Button variant="primary" rounded="none" size="sm">
-          완료
+        <Button
+          variant="primary"
+          rounded="none"
+          size="sm"
+          onClick={handleSubmit}
+          disabled={isPending || !gender}
+        >
+          {!gender ? (
+            '선택해주세요'
+          ) : isPending ? (
+            <LoadingSpinner />
+          ) : (
+            '변경하기'
+          )}
         </Button>
       </section>
     </BottomSheet>

--- a/src/pages/MyPage/components/GenderBottomSheet.tsx
+++ b/src/pages/MyPage/components/GenderBottomSheet.tsx
@@ -14,12 +14,12 @@ import { bottomSheetStyles } from '../style';
 interface GenderBottomSheetProps extends ReturnType<typeof useBoolean> {}
 
 const GenderBottomSheet = ({ value, on, off }: GenderBottomSheetProps) => {
+  const [gender, setGender] = useState<Gender>();
+
   const { mutateAsync, isPending } = useMutation({
     mutationFn: memberAPI.patchGender,
   });
   const queryClient = useQueryClient();
-
-  const [gender, setGender] = useState<Gender>();
 
   const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value as Gender;

--- a/src/pages/MyPage/components/GenderBottomSheet.tsx
+++ b/src/pages/MyPage/components/GenderBottomSheet.tsx
@@ -35,9 +35,12 @@ const GenderBottomSheet = ({ value, on, off }: GenderBottomSheetProps) => {
     }
 
     await mutateAsync({ gender });
+
     queryClient.invalidateQueries({
       queryKey: memberOptions.detail().queryKey,
     });
+
+    off();
   };
 
   return (

--- a/src/pages/MyPage/components/NicknameBottomSheet.tsx
+++ b/src/pages/MyPage/components/NicknameBottomSheet.tsx
@@ -1,4 +1,10 @@
+import { useState } from 'react';
 import { css } from '@emotion/react';
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 import useBoolean from '@/hooks/useBoolean';
 import BottomSheet from '@/components/BottomSheet';
 import Button from '@/components/Button';
@@ -6,11 +12,42 @@ import { Shuffle } from '@/assets/icons';
 import IconButton from '@/components/IconButton';
 import COLORS from '@/constants/colors';
 import textStyles from '@/styles/textStyles';
+import { getRandomItem } from '@/utils/arrayUtils';
+import { NICKNAMES } from '@/constants/users';
+import memberOptions from '@/api/member/queryOptions';
+import memberAPI from '@/api/member/apis';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import { bottomSheetStyles } from '../style';
 
 interface NicknameBottomSheetProps extends ReturnType<typeof useBoolean> {}
 
 const NicknameBottomSheet = ({ value, on, off }: NicknameBottomSheetProps) => {
+  const { data: member } = useSuspenseQuery({
+    ...memberOptions.detail(),
+    staleTime: Infinity,
+  });
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: memberAPI.patchNickname,
+  });
+  const queryClient = useQueryClient();
+
+  const [nickname, setNickname] = useState(
+    member.nickname.replace('낯선 ', ''),
+  );
+
+  const handleChangeNickname = () => {
+    setNickname(getRandomItem(NICKNAMES));
+  };
+
+  const handleSubmit = async () => {
+    await mutateAsync({ nickname: `낯선 ${nickname}` });
+
+    queryClient.invalidateQueries({
+      queryKey: memberOptions.detail().queryKey,
+    });
+    off();
+  };
+
   return (
     <BottomSheet open={value} onOpen={on} onClose={off}>
       <section css={bottomSheetStyles.mainSection}>
@@ -18,9 +55,13 @@ const NicknameBottomSheet = ({ value, on, off }: NicknameBottomSheetProps) => {
         <div css={styles.input}>
           <p css={textStyles.t3}>
             <span>낯선 </span>
-            <span css={{ color: COLORS.primaryHover }}>거북이</span>
+            <span css={{ color: COLORS.primaryHover }}>{nickname}</span>
           </p>
-          <IconButton type="button" css={styles.icon}>
+          <IconButton
+            type="button"
+            css={styles.icon}
+            onClick={handleChangeNickname}
+          >
             <Shuffle width={18} height={18} />
           </IconButton>
         </div>
@@ -30,8 +71,14 @@ const NicknameBottomSheet = ({ value, on, off }: NicknameBottomSheetProps) => {
         <Button variant="cancel" rounded="none" size="sm" onClick={off}>
           닫기
         </Button>
-        <Button variant="primary" rounded="none" size="sm">
-          완료
+        <Button
+          variant="primary"
+          rounded="none"
+          size="sm"
+          onClick={handleSubmit}
+          disabled={isPending}
+        >
+          {isPending ? <LoadingSpinner /> : '변경하기'}
         </Button>
       </section>
     </BottomSheet>

--- a/src/pages/MyPage/components/WorryBottomSheet.tsx
+++ b/src/pages/MyPage/components/WorryBottomSheet.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { css } from '@emotion/react';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 import useBoolean from '@/hooks/useBoolean';
 import BottomSheet from '@/components/BottomSheet';
 import Button from '@/components/Button';
@@ -26,6 +30,7 @@ const WorryBottomSheet = ({ value, on, off }: WorryBottomSheetProps) => {
   const { mutateAsync: postWorry, isPending: isPosting } = useMutation({
     mutationFn: memberAPI.postWorry,
   });
+  const queryClient = useQueryClient();
 
   const [worries, setWorries] = useState<Worry[]>(member.worryTypes);
 
@@ -38,6 +43,12 @@ const WorryBottomSheet = ({ value, on, off }: WorryBottomSheetProps) => {
   const handleSubmit = async () => {
     await deleteWorry();
     await postWorry({ worries });
+
+    queryClient.invalidateQueries({
+      queryKey: memberOptions.detail().queryKey,
+    });
+
+    off();
   };
 
   return (

--- a/src/pages/MyPage/components/WorryBottomSheet.tsx
+++ b/src/pages/MyPage/components/WorryBottomSheet.tsx
@@ -1,21 +1,62 @@
+import { useState } from 'react';
 import { css } from '@emotion/react';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import useBoolean from '@/hooks/useBoolean';
 import BottomSheet from '@/components/BottomSheet';
 import Button from '@/components/Button';
 import Chip from '@/components/Chip';
-import { WORRY_DICT } from '@/constants/users';
+import { WORRY_DICT, Worry } from '@/constants/users';
+import memberAPI from '@/api/member/apis';
+import memberOptions from '@/api/member/queryOptions';
+import { toggleItemInArray } from '@/utils/arrayUtils';
+import { formLiteral } from '@/pages/OnboardingPage/hooks/useOnboardingForm';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import { bottomSheetStyles } from '../style';
 
 interface WorryBottomSheetProps extends ReturnType<typeof useBoolean> {}
 
 const WorryBottomSheet = ({ value, on, off }: WorryBottomSheetProps) => {
+  const { data: member } = useSuspenseQuery({
+    ...memberOptions.detail(),
+    staleTime: Infinity,
+  });
+  const { mutateAsync: deleteWorry, isPending: isDeleting } = useMutation({
+    mutationFn: memberAPI.deleteWorry,
+  });
+  const { mutateAsync: postWorry, isPending: isPosting } = useMutation({
+    mutationFn: memberAPI.postWorry,
+  });
+
+  const [worries, setWorries] = useState<Worry[]>(member.worryTypes);
+
+  const isPending = isDeleting || isPosting;
+
+  const handleToggleWorry = (worry: Worry) => {
+    setWorries(toggleItemInArray(worries, worry));
+  };
+
+  const handleSubmit = async () => {
+    await deleteWorry();
+    await postWorry({ worries });
+  };
+
   return (
     <BottomSheet open={value} onOpen={on} onClose={off}>
       <section css={bottomSheetStyles.mainSection}>
         <h2 css={bottomSheetStyles.title}>어떤 고민으로 변경하시겠어요?</h2>
         <section css={styles.chipSection}>
           {Object.entries(WORRY_DICT).map(([key, value]) => (
-            <Chip key={key} variant="form">
+            <Chip
+              key={key}
+              variant={
+                worries.includes(key as Worry)
+                  ? 'form-selected'
+                  : worries.length < formLiteral.worries.max
+                    ? 'form'
+                    : 'form-disabled'
+              }
+              onClick={() => handleToggleWorry(key as Worry)}
+            >
               {value}
             </Chip>
           ))}
@@ -26,8 +67,14 @@ const WorryBottomSheet = ({ value, on, off }: WorryBottomSheetProps) => {
         <Button variant="cancel" rounded="none" size="sm" onClick={off}>
           닫기
         </Button>
-        <Button variant="primary" rounded="none" size="sm">
-          완료
+        <Button
+          variant="primary"
+          rounded="none"
+          size="sm"
+          disabled={worries.length === 0 || isPending}
+          onClick={handleSubmit}
+        >
+          {isPending ? <LoadingSpinner /> : '변경하기'}
         </Button>
       </section>
     </BottomSheet>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Suspense } from 'react';
 import { css } from '@emotion/react';
 import { Switch } from '@mui/material';
@@ -13,6 +13,7 @@ import memberOptions from '@/api/member/queryOptions';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { GENDER_DICT, WORRY_DICT } from '@/constants/users';
 import useMusicStore from '@/stores/useMusicStore';
+import STORAGE_KEYS from '@/constants/storageKeys';
 import styles from './style';
 import NicknameBottomSheet from './components/NicknameBottomSheet';
 import BirthdayBottomSheet from './components/BirthdayBottomSheet';
@@ -21,6 +22,7 @@ import WorryBottomSheet from './components/WorryBottomSheet';
 
 const SuspendedPage = () => {
   const { data: member } = useSuspenseQuery(memberOptions.detail());
+  const navigate = useNavigate();
 
   const nicknameBottomSheetProps = useBoolean(false);
   const birthdayBottomSheetProps = useBoolean(false);
@@ -29,6 +31,12 @@ const SuspendedPage = () => {
 
   const isMusicPlaying = useMusicStore((s) => s.isPlaying);
   const toggleMusicPlaying = useMusicStore((s) => s.togglePlaying);
+
+  const handleLogout = () => {
+    localStorage.removeItem(STORAGE_KEYS.accessToken);
+    localStorage.removeItem(STORAGE_KEYS.refreshToken);
+    navigate(ROUTER_PATHS.SIGNIN);
+  };
 
   return (
     <main css={styles.main}>
@@ -80,7 +88,10 @@ const SuspendedPage = () => {
       </ul>
       <div css={styles.divider} />
       <ul css={styles.list}>
-        <li css={[styles.item, css({ cursor: 'pointer' })]}>
+        <li
+          css={[styles.item, css({ cursor: 'pointer' })]}
+          onClick={handleLogout}
+        >
           <p>로그아웃</p>
         </li>
         <li css={[styles.item, css({ cursor: 'pointer' })]}>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,24 +1,97 @@
 import { Link } from 'react-router-dom';
+import { Suspense } from 'react';
 import { css } from '@emotion/react';
 import { Switch } from '@mui/material';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import Header from '@/components/Header';
 import { CaretLeft, CaretRight } from '@/assets/icons';
 import textStyles from '@/styles/textStyles';
 import COLORS from '@/constants/colors';
 import { ROUTER_PATHS } from '@/router';
 import useBoolean from '@/hooks/useBoolean';
+import memberOptions from '@/api/member/queryOptions';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { GENDER_DICT, WORRY_DICT } from '@/constants/users';
+import useMusicStore from '@/stores/useMusicStore';
 import styles from './style';
 import NicknameBottomSheet from './components/NicknameBottomSheet';
 import BirthdayBottomSheet from './components/BirthdayBottomSheet';
 import GenderBottomSheet from './components/GenderBottomSheet';
 import WorryBottomSheet from './components/WorryBottomSheet';
 
-const MyPage = () => {
+const SuspendedPage = () => {
+  const { data: member } = useSuspenseQuery(memberOptions.detail());
+
   const nicknameBottomSheetProps = useBoolean(false);
   const birthdayBottomSheetProps = useBoolean(false);
   const genderBottomSheetProps = useBoolean(false);
   const worryBottomSheetProps = useBoolean(false);
 
+  const isMusicPlaying = useMusicStore((s) => s.isPlaying);
+  const toggleMusicPlaying = useMusicStore((s) => s.togglePlaying);
+
+  return (
+    <main css={styles.main}>
+      <NicknameBottomSheet {...nicknameBottomSheetProps} />
+      <BirthdayBottomSheet {...birthdayBottomSheetProps} />
+      <GenderBottomSheet {...genderBottomSheetProps} />
+      <WorryBottomSheet {...worryBottomSheetProps} />
+      <ul css={styles.list}>
+        <li css={styles.item}>
+          <p>닉네임 변경</p>
+          <div css={styles.value} onClick={nicknameBottomSheetProps.on}>
+            <span>{member.nickname}</span>
+            <CaretRight color={COLORS.gray3} />
+          </div>
+        </li>
+        <li css={styles.item}>
+          <p>생년월일 변경</p>
+          <div css={styles.value} onClick={birthdayBottomSheetProps.on}>
+            {/* TODO: API 명세에 생년월일 추가 요청해야함 */}
+            <span>1997년 1월 1일</span>
+            <CaretRight color={COLORS.gray3} />
+          </div>
+        </li>
+        <li css={styles.item}>
+          <p>성별 변경</p>
+          <div css={styles.value} onClick={genderBottomSheetProps.on}>
+            <span>{GENDER_DICT[member.gender]}</span>
+            <CaretRight color={COLORS.gray3} />
+          </div>
+        </li>
+        <li css={styles.item}>
+          <p>고민 변경</p>
+          <div css={styles.value} onClick={worryBottomSheetProps.on}>
+            {member.worryTypes.map((worryType) => (
+              <span css={styles.chip} key={worryType}>
+                {WORRY_DICT[worryType]}
+              </span>
+            ))}
+            <CaretRight color={COLORS.gray3} />
+          </div>
+        </li>
+      </ul>
+      <div css={styles.divider} />
+      <ul css={styles.list}>
+        <div css={[styles.item, css({ margin: '-0.5rem 0' })]}>
+          <p>배경음악</p>
+          <Switch checked={isMusicPlaying} onChange={toggleMusicPlaying} />
+        </div>
+      </ul>
+      <div css={styles.divider} />
+      <ul css={styles.list}>
+        <li css={[styles.item, css({ cursor: 'pointer' })]}>
+          <p>로그아웃</p>
+        </li>
+        <li css={[styles.item, css({ cursor: 'pointer' })]}>
+          <p css={css({ color: COLORS.red })}>서비스 탈퇴</p>
+        </li>
+      </ul>
+    </main>
+  );
+};
+
+const MyPage = () => {
   return (
     <div css={styles.page}>
       <Header
@@ -29,60 +102,15 @@ const MyPage = () => {
         }
         centerContent={<h1 css={textStyles.b4m}>마이페이지</h1>}
       />
-      <main css={styles.main}>
-        <ul css={styles.list}>
-          <li css={styles.item}>
-            <p>닉네임 변경</p>
-            <div css={styles.value} onClick={nicknameBottomSheetProps.on}>
-              <span>낯선 거북이</span>
-              <CaretRight color={COLORS.gray3} />
-            </div>
-          </li>
-          <li css={styles.item}>
-            <p>생년월일 변경</p>
-            <div css={styles.value} onClick={birthdayBottomSheetProps.on}>
-              <span>1997년 1월 1일</span>
-              <CaretRight color={COLORS.gray3} />
-            </div>
-          </li>
-          <li css={styles.item}>
-            <p>성별 변경</p>
-            <div css={styles.value} onClick={genderBottomSheetProps.on}>
-              <span>여성</span>
-              <CaretRight color={COLORS.gray3} />
-            </div>
-          </li>
-          <li css={styles.item}>
-            <p>고민 변경</p>
-            <div css={styles.value} onClick={worryBottomSheetProps.on}>
-              <span css={styles.chip}>취업·진로</span>
-              <span css={styles.chip}>학업</span>
-              <span css={styles.chip}>인간관계</span>
-              <CaretRight color={COLORS.gray3} />
-            </div>
-          </li>
-        </ul>
-        <div css={styles.divider} />
-        <ul css={styles.list}>
-          <div css={[styles.item, css({ margin: '-0.5rem 0' })]}>
-            <p>배경음악</p>
-            <Switch />
-          </div>
-        </ul>
-        <div css={styles.divider} />
-        <ul css={styles.list}>
-          <li css={[styles.item, css({ cursor: 'pointer' })]}>
-            <p>로그아웃</p>
-          </li>
-          <li css={[styles.item, css({ cursor: 'pointer' })]}>
-            <p css={css({ color: COLORS.red })}>서비스 탈퇴</p>
-          </li>
-        </ul>
-      </main>
-      <NicknameBottomSheet {...nicknameBottomSheetProps} />
-      <BirthdayBottomSheet {...birthdayBottomSheetProps} />
-      <GenderBottomSheet {...genderBottomSheetProps} />
-      <WorryBottomSheet {...worryBottomSheetProps} />
+      <Suspense
+        fallback={
+          <section css={styles.loadingSection}>
+            <LoadingSpinner size="4rem" />
+          </section>
+        }
+      >
+        <SuspendedPage />
+      </Suspense>
     </div>
   );
 };

--- a/src/pages/MyPage/style.ts
+++ b/src/pages/MyPage/style.ts
@@ -50,6 +50,13 @@ const styles = {
     background: rgb(12 140 233 / 0.05);
     color: ${COLORS.primary};
   `,
+  loadingSection: css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-top: 3rem;
+  `,
 };
 
 export const bottomSheetStyles = {

--- a/src/pages/OnboardingPage/hooks/useOnboardingForm.ts
+++ b/src/pages/OnboardingPage/hooks/useOnboardingForm.ts
@@ -50,7 +50,7 @@ export const formSchema = z.object({
     .max(L.worries.max),
 });
 
-const initialSchema = formSchema.omit({ birthday: true }).extend({
+export const initialSchema = formSchema.omit({ birthday: true }).extend({
   birthday: z.object({
     year: z.literal(''),
     month: z.literal(''),

--- a/src/pages/SigninPage/index.tsx
+++ b/src/pages/SigninPage/index.tsx
@@ -1,30 +1,14 @@
 import KakaoLoginButton from '@/components/KakaoLoginButton';
 import Header from '@/components/Header';
-import IconButton from '@/components/IconButton';
-import { SoundOff } from '@/assets/icons';
-import Tooltip from '@/components/Tooltip';
 import textStyles from '@/styles/textStyles';
+import MusicButton from '@/components/MusicButton';
 import styles from './styles';
 
 const SigninPage = () => {
   return (
     <div css={styles.page}>
       <Header />
-      <Header
-        rightContent={
-          <Tooltip
-            side="bottom"
-            align="end"
-            triggerContent={
-              <IconButton>
-                <SoundOff color="white" />
-              </IconButton>
-            }
-          >
-            소리를 켜 바다를 느껴보세요
-          </Tooltip>
-        }
-      />
+      <Header rightContent={<MusicButton />} />
 
       <main css={styles.main}>
         <p css={textStyles.b3R}>아무도에게도 말 못한 마음 속 편지</p>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #104

## ✅ 작업 사항
- 마이 페이지에서 사용자의 상호작용 및 API 호출 로직 작성
- Chip의 form-disabled 속성 추가
  - 디자인 상에는 없긴 한데, 온보딩의 primary와 동작을 동일하게 하려면 있어야 할 것 같아서 추가했어요!
- GenderCard 스토리북에서 onClick 대신 onChange 를 사용하는 방식으로 리팩토링

### 닉네임 변경
![1 닉네임](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/08c91ed5-f06a-423a-8ef5-e254bea9c2cf)

### 생년월일 변경
![2 생년월일](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/8a573670-e23c-4258-a5dc-3ed682d3fe16)

### 성별 변경
![3 성별](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/857a8578-a62c-4e14-b4ff-b8eb797e72ec)

### 고민 변경
![4 고민](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/5175bbac-523a-4396-8ceb-6bd9964074e1)

중점적으로 생각했던 부분은 생년월일과 성별과 같이 **단 한번만 변경 가능한 경우에는 기본 값을 없게 하고, 사용자가 반드시 입력**하도록 해서 신중하게 결정할 수 있도록 유도하는 부분이었어요.

반대로 닉네임과 고민과 같이 제한 없이 변경 가능한 경우에는 **사용자의 정보를 기본 값**으로 넣어줬어요.

## 👩‍💻 공유 포인트 및 논의 사항
자신의 생년월일을 마이 페이지에서 보여줘야 하는데, API에서 받아올 수 있는 정보가 없어서 백엔드 팀원분들께 요청드려야 할 것 같아요!