### PR TITLE
🚑 fix: Preview 배포에서 로그인 되어있도록 설정

### DIFF
--- a/src/api/letter/apis.ts
+++ b/src/api/letter/apis.ts
@@ -15,12 +15,8 @@ const letterAPI = {
   },
 
   /** 답장 받은 편지 페이징 조회 */
-  getRepliedLetters: async (page: number) => {
-    const { data } = await authInstance.get<Reply[]>(`/api/letter/reply`, {
-      params: {
-        page,
-      },
-    });
+  getRepliedLetters: async () => {
+    const { data } = await authInstance.get<Reply[]>(`/api/letter/reply`);
     return data;
   },
 

--- a/src/api/letter/queryOptions.ts
+++ b/src/api/letter/queryOptions.ts
@@ -10,10 +10,10 @@ const letterOptions = {
       queryFn: () => letterAPI.getReceivedLetters(),
     }),
 
-  reply: (page: number) =>
+  reply: () =>
     queryOptions({
-      queryKey: [...letterOptions.all, 'reply', page] as const,
-      queryFn: () => letterAPI.getRepliedLetters(page),
+      queryKey: [...letterOptions.all, 'reply'] as const,
+      queryFn: () => letterAPI.getRepliedLetters(),
     }),
 
   singleReception: (letterId: number) =>

--- a/src/components/ErrorBoundary/fallback/RootApiFallback.tsx
+++ b/src/components/ErrorBoundary/fallback/RootApiFallback.tsx
@@ -10,7 +10,8 @@ const RootApiFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
   const shouldSkip =
     !isAxiosError(error) ||
     error.response?.data === ERROR_RESPONSES.accessExpired ||
-    error.response?.data === ERROR_RESPONSES.reissueFailed;
+    error.response?.data === ERROR_RESPONSES.reissueFailed ||
+    error.response?.data === ERROR_RESPONSES.authenticationEntryPoint;
 
   useEffect(() => {
     if (shouldSkip) {

--- a/src/components/ErrorBoundary/fallback/RootUnknownFallback.tsx
+++ b/src/components/ErrorBoundary/fallback/RootUnknownFallback.tsx
@@ -13,7 +13,8 @@ const RootUnknownFallback = ({ error }: FallbackProps) => {
 
   const shouldSkip =
     isAxiosError(error) &&
-    error.response?.data === ERROR_RESPONSES.reissueFailed;
+    (error.response?.data === ERROR_RESPONSES.reissueFailed ||
+      error.response?.data === ERROR_RESPONSES.authenticationEntryPoint);
 
   useEffect(() => {
     if (shouldSkip) {

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -1,4 +1,5 @@
 const ERROR_RESPONSES = {
+  authenticationEntryPoint: '로그인이 필요한 요청 입니다.',
   accessExpired: '액세스 토큰이 만료되었습니다.',
   reissueFailed: '리프레시 토큰이 올바르지 않습니다. 다시 로그인해주세요.',
   usernameNotFound: '존재하지 않는 회원입니다.',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import { router } from '@/router';
 import { SKIP_MSW_WARNING_URL } from './constants/msw';
 import 'reset-css';
 import './main.css';
+import STORAGE_KEYS from './constants/storageKeys';
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
@@ -31,6 +32,15 @@ Sentry.init({
 const enableMocking = async () => {
   if (import.meta.env.VITE_MSW !== 'on') {
     return;
+  }
+
+  // Preview 배포 시, 로컬 스토리지에 토큰을 저장하여 로그인 상태로 만듭니다.
+  if (
+    import.meta.env.PROD &&
+    !localStorage.getItem(STORAGE_KEYS.refreshToken)
+  ) {
+    localStorage.setItem(STORAGE_KEYS.accessToken, 'fresh');
+    localStorage.setItem(STORAGE_KEYS.refreshToken, 'fresh');
   }
 
   const { worker } = await import('@/mocks/browser');

--- a/src/pages/MainPage/hooks/useLetterSlides.ts
+++ b/src/pages/MainPage/hooks/useLetterSlides.ts
@@ -11,7 +11,7 @@ const REPLIES_PER_SLIDE = 2;
 
 const useLetterSlides = () => {
   const [{ data: receptions }, { data: replies }] = useSuspenseQueries({
-    queries: [letterOptions.reception(), letterOptions.reply(0)],
+    queries: [letterOptions.reception(), letterOptions.reply()],
   });
 
   const refinedReceptions = chunkArray(


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #121 

## ✅ 작업 사항
- Preview 배포에서 로그인 되어있도록 설정
- "로그인이 필요한 요청 입니다." 라는 응답을 받으면 로그인 페이지로 리다이렉션
- GET /api/letter/reply 요청에서 query params 제거

## 👩‍💻 공유 포인트 및 논의 사항
