### PR TITLE
🔨 refactor: 편지쓰기 formData 이미지 유무에 따른 처리 방식 수정

### DIFF
--- a/src/api/letter/apis.ts
+++ b/src/api/letter/apis.ts
@@ -31,7 +31,10 @@ const letterAPI = {
     formData.append('ageRangeStart', letter.age[0].toString());
     formData.append('ageRangeEnd', letter.age[1].toString());
     formData.append('worryType', letter.worryType as Worry);
-    formData.append('image', letter.image?.[0]);
+
+    if (letter.image) {
+      formData.append('image', letter.image[0]);
+    }
 
     const { data } = await authInstance.post('/api/letter', formData, {
       headers: {


### PR DESCRIPTION
## 🧩 이슈 번호

- close #132 

## ✅ 작업 사항

이미지가 없을 경우 formData 에 image 필드를 안보내도록 수정했습니다.

이미지를 등록했다가 삭제할 경우에도 image 필드 또한 안들어갑니다.

<img width="460" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/e9d69ce4-f342-49b5-960a-b4d6063670d9">


## 👩‍💻 공유 포인트 및 논의 사항
