### PR TITLE
🔨 refactor: msw 모킹 정리 및 withAuth 미들웨어 작성

### DIFF
--- a/src/api/member/apis.ts
+++ b/src/api/member/apis.ts
@@ -10,8 +10,8 @@ const memberAPI = {
       nickname: string | null;
       worryTypes: Worry[];
       gender: Gender | null;
-      birthday: [number, number, number] | null;
-      age: number;
+      birthDay: [number, number, number] | null;
+      age: number | null;
       role: Role;
     }>('/api/member');
     return data;

--- a/src/constants/queryStrings.ts
+++ b/src/constants/queryStrings.ts
@@ -1,6 +1,0 @@
-const QUERY_STRINGS = {
-  mswCase: 'mswCase',
-  mswItemCount: 'mswItemCount',
-} as const;
-
-export default QUERY_STRINGS;

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -13,19 +13,13 @@ const letterHandler = [
     withAuth(async () => {
       await delay(1000);
 
-      const status: number = 200;
       const itemCount =
         Number(getSearchParams('mswItemCount')) ||
         ReceivedLetterResponse.length;
 
-      switch (status) {
-        case 200:
-          return HttpResponse.json(
-            ReceivedLetterResponse.slice(0, Number(itemCount)),
-          );
-        default:
-          break;
-      }
+      return HttpResponse.json(
+        ReceivedLetterResponse.slice(0, Number(itemCount)),
+      );
     }),
   ),
 
@@ -34,19 +28,13 @@ const letterHandler = [
     withAuth(async () => {
       await delay(1000);
 
-      const status: number = 200;
       const itemCount =
         Number(getSearchParams('mswItemCount')) ||
         RepliedLettersResponse.length;
 
-      switch (status) {
-        case 200:
-          return HttpResponse.json(
-            RepliedLettersResponse.slice(0, Number(itemCount)),
-          );
-        default:
-          break;
-      }
+      return HttpResponse.json(
+        RepliedLettersResponse.slice(0, Number(itemCount)),
+      );
     }),
   ),
 
@@ -64,7 +52,6 @@ const letterHandler = [
     withAuth(async (req) => {
       await delay(300);
 
-      const status: number = 200;
       const result: Reception = {
         createdAt: '2024-02-13T16:50:44',
         letterId: Number(req.params.letterId),
@@ -73,15 +60,6 @@ const letterHandler = [
         content: `${req.params.letterId} 번째 편지 입니다. 여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대 부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오`,
         worryType: 'BREAK_LOVE',
       };
-
-      switch (status) {
-        case 200:
-          return HttpResponse.json(result, {
-            status,
-          });
-        default:
-          break;
-      }
 
       return HttpResponse.json(result);
     }),
@@ -110,7 +88,6 @@ const letterHandler = [
     withAuth(async (req) => {
       await delay(300);
 
-      const status: number = 200;
       const result: Reply = {
         createdAt: '2024-02-13T16:50:44',
         letterId: Number(req.params.letterId),
@@ -121,12 +98,7 @@ const letterHandler = [
         worryType: 'BREAK_LOVE',
       };
 
-      switch (status) {
-        case 200:
-          return HttpResponse.json(result);
-        default:
-          break;
-      }
+      return HttpResponse.json(result);
     }),
   ),
 

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -1,74 +1,63 @@
 import { http, HttpResponse, delay } from 'msw';
-import { baseURL, isValidToken } from '@/utils/mswUtils';
-import QUERY_STRINGS from '@/constants/queryStrings';
+import { baseURL } from '@/utils/mswUtils';
 import { Reception, Reply } from '@/types/letter';
 import ERROR_RESPONSES from '@/constants/errorMessages';
-import STORAGE_KEYS from '@/constants/storageKeys';
 import {
   ReceivedLetterResponse,
   RepliedLettersResponse,
 } from '../datas/letter';
 
 const letterHandler = [
-  http.get(baseURL('/api/letter/reception'), async (req) => {
-    const accessToken = req.request.headers.get(STORAGE_KEYS.accessToken);
-
+  http.get(baseURL('/api/letter/reception'), async () => {
     await delay(1000);
 
     const itemCount =
-      Number(
-        new URLSearchParams(window.location.search).get(
-          QUERY_STRINGS.mswItemCount,
-        ),
-      ) || ReceivedLetterResponse.length;
+      Number(new URLSearchParams(window.location.search).get('mswItemCount')) ||
+      ReceivedLetterResponse.length;
 
-    if (isValidToken(accessToken)) {
-      return HttpResponse.json(
-        ReceivedLetterResponse.slice(0, Number(itemCount)),
-      );
-    } else {
-      return new HttpResponse(ERROR_RESPONSES.accessExpired, { status: 401 });
+    const status: number = 200;
+
+    switch (status) {
+      case 200:
+        return HttpResponse.json(
+          ReceivedLetterResponse.slice(0, Number(itemCount)),
+        );
+      case 401:
+        return new HttpResponse(ERROR_RESPONSES.accessExpired, { status });
+      default:
+        break;
     }
   }),
 
-  http.get(baseURL('/api/letter/reply'), async (req) => {
-    const accessToken = req.request.headers.get(STORAGE_KEYS.accessToken);
-
+  http.get(baseURL('/api/letter/reply'), async () => {
     await delay(1000);
 
     const itemCount =
-      Number(
-        new URLSearchParams(window.location.search).get(
-          QUERY_STRINGS.mswItemCount,
-        ),
-      ) || RepliedLettersResponse.length;
+      Number(new URLSearchParams(window.location.search).get('mswItemCount')) ||
+      ReceivedLetterResponse.length;
 
-    if (isValidToken(accessToken)) {
-      return HttpResponse.json(
-        RepliedLettersResponse.slice(0, Number(itemCount)),
-      );
-    } else {
-      return new HttpResponse(ERROR_RESPONSES.accessExpired, { status: 401 });
+    const status: number = 200;
+
+    switch (status) {
+      case 200:
+        return HttpResponse.json(
+          RepliedLettersResponse.slice(0, Number(itemCount)),
+        );
+      case 401:
+        return new HttpResponse(ERROR_RESPONSES.accessExpired, { status });
+      default:
+        break;
     }
   }),
 
   http.post(baseURL('/api/letter'), async () => {
     await delay(1000);
+
     return HttpResponse.json();
   }),
 
   http.get(baseURL('/api/letter/reception/:letterId'), async (req) => {
     await delay(300);
-
-    const mswCase = new URLSearchParams(window.location.search).get(
-      QUERY_STRINGS.mswCase,
-    );
-
-    if (mswCase === '400') {
-      return new HttpResponse(ERROR_RESPONSES.accessDeniedLetter, {
-        status: 400,
-      });
-    }
 
     const result: Reception = {
       createdAt: '2024-02-13T16:50:44',
@@ -78,6 +67,19 @@ const letterHandler = [
       content: `${req.params.letterId} 번째 편지 입니다. 여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대 부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오`,
       worryType: 'BREAK_LOVE',
     };
+
+    const status: number = 200;
+
+    switch (status) {
+      case 200:
+        return HttpResponse.json(result, {
+          status,
+        });
+      case 400:
+        return new HttpResponse(ERROR_RESPONSES.accessDeniedLetter, { status });
+      default:
+        break;
+    }
 
     return HttpResponse.json(result);
   }),
@@ -107,7 +109,14 @@ const letterHandler = [
       worryType: 'BREAK_LOVE',
     };
 
-    return HttpResponse.json(result);
+    const status: number = 200;
+
+    switch (status) {
+      case 200:
+        return HttpResponse.json(result);
+      default:
+        break;
+    }
   }),
 
   http.patch(baseURL('/api/letter/reception/storage/:letterId'), async () => {

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse, delay } from 'msw';
-import { baseURL } from '@/utils/mswUtils';
+import { baseURL, getSearchParams } from '@/utils/mswUtils';
 import { Reception, Reply } from '@/types/letter';
 import ERROR_RESPONSES from '@/constants/errorMessages';
 import {
@@ -12,8 +12,7 @@ const letterHandler = [
     await delay(1000);
 
     const itemCount =
-      Number(new URLSearchParams(window.location.search).get('mswItemCount')) ||
-      ReceivedLetterResponse.length;
+      Number(getSearchParams('mswItemCount')) || ReceivedLetterResponse.length;
 
     const status: number = 200;
 
@@ -33,8 +32,7 @@ const letterHandler = [
     await delay(1000);
 
     const itemCount =
-      Number(new URLSearchParams(window.location.search).get('mswItemCount')) ||
-      ReceivedLetterResponse.length;
+      Number(getSearchParams('mswItemCount')) || RepliedLettersResponse.length;
 
     const status: number = 200;
 

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -1,127 +1,143 @@
 import { http, HttpResponse, delay } from 'msw';
 import { baseURL, getSearchParams } from '@/utils/mswUtils';
 import { Reception, Reply } from '@/types/letter';
-import ERROR_RESPONSES from '@/constants/errorMessages';
 import {
   ReceivedLetterResponse,
   RepliedLettersResponse,
 } from '../datas/letter';
+import withAuth from '../middlewares/withAuth';
 
 const letterHandler = [
-  http.get(baseURL('/api/letter/reception'), async () => {
-    await delay(1000);
+  http.get(
+    baseURL('/api/letter/reception'),
+    withAuth(async () => {
+      await delay(1000);
 
-    const itemCount =
-      Number(getSearchParams('mswItemCount')) || ReceivedLetterResponse.length;
+      const status: number = 200;
+      const itemCount =
+        Number(getSearchParams('mswItemCount')) ||
+        ReceivedLetterResponse.length;
 
-    const status: number = 200;
+      switch (status) {
+        case 200:
+          return HttpResponse.json(
+            ReceivedLetterResponse.slice(0, Number(itemCount)),
+          );
+        default:
+          break;
+      }
+    }),
+  ),
 
-    switch (status) {
-      case 200:
-        return HttpResponse.json(
-          ReceivedLetterResponse.slice(0, Number(itemCount)),
-        );
-      case 401:
-        return new HttpResponse(ERROR_RESPONSES.accessExpired, { status });
-      default:
-        break;
-    }
-  }),
+  http.get(
+    baseURL('/api/letter/reply'),
+    withAuth(async () => {
+      await delay(1000);
 
-  http.get(baseURL('/api/letter/reply'), async () => {
-    await delay(1000);
+      const status: number = 200;
+      const itemCount =
+        Number(getSearchParams('mswItemCount')) ||
+        RepliedLettersResponse.length;
 
-    const itemCount =
-      Number(getSearchParams('mswItemCount')) || RepliedLettersResponse.length;
+      switch (status) {
+        case 200:
+          return HttpResponse.json(
+            RepliedLettersResponse.slice(0, Number(itemCount)),
+          );
+        default:
+          break;
+      }
+    }),
+  ),
 
-    const status: number = 200;
+  http.post(
+    baseURL('/api/letter'),
+    withAuth(async () => {
+      await delay(1000);
 
-    switch (status) {
-      case 200:
-        return HttpResponse.json(
-          RepliedLettersResponse.slice(0, Number(itemCount)),
-        );
-      case 401:
-        return new HttpResponse(ERROR_RESPONSES.accessExpired, { status });
-      default:
-        break;
-    }
-  }),
+      return HttpResponse.json();
+    }),
+  ),
 
-  http.post(baseURL('/api/letter'), async () => {
-    await delay(1000);
+  http.get(
+    baseURL('/api/letter/reception/:letterId'),
+    withAuth(async (req) => {
+      await delay(300);
 
-    return HttpResponse.json();
-  }),
+      const status: number = 200;
+      const result: Reception = {
+        createdAt: '2024-02-13T16:50:44',
+        letterId: Number(req.params.letterId),
+        senderNickname: '낯선 고양이123',
+        receiverNickname: '낯선 강아지456',
+        content: `${req.params.letterId} 번째 편지 입니다. 여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대 부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오`,
+        worryType: 'BREAK_LOVE',
+      };
 
-  http.get(baseURL('/api/letter/reception/:letterId'), async (req) => {
-    await delay(300);
+      switch (status) {
+        case 200:
+          return HttpResponse.json(result, {
+            status,
+          });
+        default:
+          break;
+      }
 
-    const result: Reception = {
-      createdAt: '2024-02-13T16:50:44',
-      letterId: Number(req.params.letterId),
-      senderNickname: '낯선 고양이123',
-      receiverNickname: '낯선 강아지456',
-      content: `${req.params.letterId} 번째 편지 입니다. 여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대 부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오`,
-      worryType: 'BREAK_LOVE',
-    };
+      return HttpResponse.json(result);
+    }),
+  ),
 
-    const status: number = 200;
+  http.patch(
+    baseURL('/api/letter/reception/reply/:letterId'),
+    withAuth(async () => {
+      await delay(1000);
 
-    switch (status) {
-      case 200:
-        return HttpResponse.json(result, {
-          status,
-        });
-      case 400:
-        return new HttpResponse(ERROR_RESPONSES.accessDeniedLetter, { status });
-      default:
-        break;
-    }
+      return HttpResponse.json();
+    }),
+  ),
 
-    return HttpResponse.json(result);
-  }),
+  http.patch(
+    baseURL('/api/letter/reception/toss/:letterId'),
+    withAuth(async () => {
+      await delay(1000);
 
-  http.patch(baseURL('/api/letter/reception/reply/:letterId'), async () => {
-    await delay(1000);
+      return HttpResponse.json();
+    }),
+  ),
 
-    return HttpResponse.json();
-  }),
+  http.get(
+    baseURL('/api/letter/reply/:letterId'),
+    withAuth(async (req) => {
+      await delay(300);
 
-  http.patch(baseURL('/api/letter/reception/toss/:letterId'), async () => {
-    await delay(1000);
+      const status: number = 200;
+      const result: Reply = {
+        createdAt: '2024-02-13T16:50:44',
+        letterId: Number(req.params.letterId),
+        senderNickname: '낯선 고양이123',
+        receiverNickname: '낯선 강아지456',
+        content: `${req.params.letterId} 번째 편지 입니다. 여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대 부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오`,
+        repliedContent: `${req.params.letterId} 번째 편지 답장 입니다.`,
+        worryType: 'BREAK_LOVE',
+      };
 
-    return HttpResponse.json();
-  }),
+      switch (status) {
+        case 200:
+          return HttpResponse.json(result);
+        default:
+          break;
+      }
+    }),
+  ),
 
-  http.get(baseURL('/api/letter/reply/:letterId'), async (req) => {
-    await delay(300);
+  http.patch(
+    baseURL('/api/letter/reception/storage/:letterId'),
+    withAuth(async () => {
+      await delay(1000);
 
-    const result: Reply = {
-      createdAt: '2024-02-13T16:50:44',
-      letterId: Number(req.params.letterId),
-      senderNickname: '낯선 고양이123',
-      receiverNickname: '낯선 강아지456',
-      content: `${req.params.letterId} 번째 편지 입니다. 여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대 부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오`,
-      repliedContent: `${req.params.letterId} 번째 편지 답장 입니다.`,
-      worryType: 'BREAK_LOVE',
-    };
-
-    const status: number = 200;
-
-    switch (status) {
-      case 200:
-        return HttpResponse.json(result);
-      default:
-        break;
-    }
-  }),
-
-  http.patch(baseURL('/api/letter/reception/storage/:letterId'), async () => {
-    await delay(1000);
-
-    return HttpResponse.json();
-  }),
+      return HttpResponse.json();
+    }),
+  ),
 ];
 
 export default letterHandler;

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -1,7 +1,6 @@
 import { http, HttpResponse, delay } from 'msw';
 import memberAPI from '@/api/member/apis';
 import { baseURL, getSearchParams } from '@/utils/mswUtils';
-import QUERY_STRINGS from '@/constants/queryStrings';
 import ERROR_RESPONSES from '@/constants/errorMessages';
 import withAuth from '../middlewares/withAuth';
 
@@ -45,7 +44,7 @@ const memberHandler = [
           }
         case 404:
           return new HttpResponse(ERROR_RESPONSES.memberNotFound, {
-            status: 404,
+            status,
           });
         default:
           return;
@@ -58,17 +57,18 @@ const memberHandler = [
     withAuth(async () => {
       await delay(1000);
 
-      const mswCase = new URLSearchParams(window.location.search).get(
-        QUERY_STRINGS.mswCase,
-      );
+      const status: number = 200;
 
-      if (mswCase === '404') {
-        return new HttpResponse(ERROR_RESPONSES.memberNotFound, {
-          status: 404,
-        });
+      switch (status) {
+        case 200:
+          return HttpResponse.json();
+        case 404:
+          return new HttpResponse(ERROR_RESPONSES.memberNotFound, {
+            status,
+          });
+        default:
+          return;
       }
-
-      return HttpResponse.json();
     }),
   ),
 

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -3,97 +3,119 @@ import memberAPI from '@/api/member/apis';
 import { baseURL, getSearchParams } from '@/utils/mswUtils';
 import QUERY_STRINGS from '@/constants/queryStrings';
 import ERROR_RESPONSES from '@/constants/errorMessages';
+import withAuth from '../middlewares/withAuth';
 
 const memberHandler = [
-  http.get(baseURL('/api/member'), async () => {
-    await delay(300);
+  http.get(
+    baseURL('/api/member'),
+    withAuth(async () => {
+      await delay(300);
 
-    const status: number = 200;
-    const mswCase = getSearchParams('mswCase');
+      const status: number = 200;
+      const mswCase = getSearchParams('mswCase');
 
-    switch (status) {
-      case 200:
-        if (mswCase === 'empty') {
-          return HttpResponse.json({
-            id: 8,
-            email: 'aodem@naver.com',
-            nickname: null,
-            worryTypes: [],
-            gender: null,
-            birthDay: null,
-            age: null,
-            role: 'USER',
-          } satisfies Awaited<
-            ReturnType<(typeof memberAPI)['getMemberDetail']>
-          >);
-        } else {
-          return HttpResponse.json({
-            id: 7,
-            email: 'tnlswodnjs99@naver.com',
-            nickname: '낯선 거북이',
-            worryTypes: ['COURSE', 'STUDY', 'RELATIONSHIP'],
-            gender: 'MALE',
-            birthDay: [1997, 1, 1],
-            age: 28,
-            role: 'USER',
-          } satisfies Awaited<
-            ReturnType<(typeof memberAPI)['getMemberDetail']>
-          >);
-        }
-      case 404:
+      switch (status) {
+        case 200:
+          if (mswCase === 'empty') {
+            return HttpResponse.json({
+              id: 8,
+              email: 'aodem@naver.com',
+              nickname: null,
+              worryTypes: [],
+              gender: null,
+              birthDay: null,
+              age: null,
+              role: 'USER',
+            } satisfies Awaited<
+              ReturnType<(typeof memberAPI)['getMemberDetail']>
+            >);
+          } else {
+            return HttpResponse.json({
+              id: 7,
+              email: 'tnlswodnjs99@naver.com',
+              nickname: '낯선 거북이',
+              worryTypes: ['COURSE', 'STUDY', 'RELATIONSHIP'],
+              gender: 'MALE',
+              birthDay: [1997, 1, 1],
+              age: 28,
+              role: 'USER',
+            } satisfies Awaited<
+              ReturnType<(typeof memberAPI)['getMemberDetail']>
+            >);
+          }
+        case 404:
+          return new HttpResponse(ERROR_RESPONSES.memberNotFound, {
+            status: 404,
+          });
+        default:
+          return;
+      }
+    }),
+  ),
+
+  http.patch(
+    baseURL('/api/member'),
+    withAuth(async () => {
+      await delay(1000);
+
+      const mswCase = new URLSearchParams(window.location.search).get(
+        QUERY_STRINGS.mswCase,
+      );
+
+      if (mswCase === '404') {
         return new HttpResponse(ERROR_RESPONSES.memberNotFound, {
           status: 404,
         });
-      default:
-        return;
-    }
-  }),
+      }
 
-  http.patch(baseURL('/api/member'), async () => {
-    await delay(1000);
+      return HttpResponse.json();
+    }),
+  ),
 
-    const mswCase = new URLSearchParams(window.location.search).get(
-      QUERY_STRINGS.mswCase,
-    );
+  http.patch(
+    baseURL('/api/member/nickname'),
+    withAuth(async () => {
+      await delay(1000);
 
-    if (mswCase === '404') {
-      return new HttpResponse(ERROR_RESPONSES.memberNotFound, {
-        status: 404,
-      });
-    }
+      return HttpResponse.json();
+    }),
+  ),
 
-    return HttpResponse.json();
-  }),
+  http.patch(
+    baseURL('/api/member/birthday'),
+    withAuth(async () => {
+      await delay(1000);
 
-  http.patch(baseURL('/api/member/nickname'), async () => {
-    await delay(1000);
+      return HttpResponse.json();
+    }),
+  ),
 
-    return HttpResponse.json();
-  }),
+  http.patch(
+    baseURL('/api/member/gender'),
+    withAuth(async () => {
+      await delay(1000);
 
-  http.patch(baseURL('/api/member/birthday'), async () => {
-    await delay(1000);
+      return HttpResponse.json();
+    }),
+  ),
 
-    return HttpResponse.json();
-  }),
+  http.delete(
+    baseURL('/api/member/worry'),
+    withAuth(async () => {
+      await delay(1000);
 
-  http.patch(baseURL('/api/member/gender'), async () => {
-    await delay(1000);
+      return HttpResponse.json();
+    }),
+  ),
 
-    return HttpResponse.json();
-  }),
+  http.post(
+    baseURL('/api/member/worry'),
+    withAuth(async () => {
+      await delay(1000);
 
-  http.delete(baseURL('/api/member/worry'), async () => {
-    await delay(1000);
-
-    return HttpResponse.json();
-  }),
-
-  http.post(baseURL('/api/member/worry'), async () => {
-    await delay(1000);
-
-    return HttpResponse.json();
-  }),
+      return HttpResponse.json();
+    }),
+  ),
 ];
 
 export default memberHandler;

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse, delay } from 'msw';
 import memberAPI from '@/api/member/apis';
-import { baseURL } from '@/utils/mswUtils';
+import { baseURL, getSearchParams } from '@/utils/mswUtils';
 import QUERY_STRINGS from '@/constants/queryStrings';
 import ERROR_RESPONSES from '@/constants/errorMessages';
 
@@ -8,39 +8,45 @@ const memberHandler = [
   http.get(baseURL('/api/member'), async () => {
     await delay(300);
 
-    const mswCase = new URLSearchParams(window.location.search).get(
-      QUERY_STRINGS.mswCase,
-    );
+    const status: number = 200;
+    const mswCase = getSearchParams('mswCase');
 
-    if (mswCase === '404') {
-      return new HttpResponse(ERROR_RESPONSES.memberNotFound, {
-        status: 404,
-      });
-    } else if (mswCase === 'empty') {
-      return HttpResponse.json({
-        id: 8,
-        email: 'aodem@naver.com',
-        nickname: null,
-        worryTypes: [],
-        gender: null,
-        birthDay: null,
-        age: null,
-        role: 'USER',
-      });
+    switch (status) {
+      case 200:
+        if (mswCase === 'empty') {
+          return HttpResponse.json({
+            id: 8,
+            email: 'aodem@naver.com',
+            nickname: null,
+            worryTypes: [],
+            gender: null,
+            birthDay: null,
+            age: null,
+            role: 'USER',
+          } satisfies Awaited<
+            ReturnType<(typeof memberAPI)['getMemberDetail']>
+          >);
+        } else {
+          return HttpResponse.json({
+            id: 7,
+            email: 'tnlswodnjs99@naver.com',
+            nickname: '낯선 거북이',
+            worryTypes: ['COURSE', 'STUDY', 'RELATIONSHIP'],
+            gender: 'MALE',
+            birthDay: [1997, 1, 1],
+            age: 28,
+            role: 'USER',
+          } satisfies Awaited<
+            ReturnType<(typeof memberAPI)['getMemberDetail']>
+          >);
+        }
+      case 404:
+        return new HttpResponse(ERROR_RESPONSES.memberNotFound, {
+          status: 404,
+        });
+      default:
+        return;
     }
-
-    const result = {
-      id: 7,
-      email: 'tnlswodnjs99@naver.com',
-      nickname: '낯선 거북이',
-      worryTypes: ['COURSE', 'STUDY', 'RELATIONSHIP'],
-      gender: 'MALE',
-      birthday: [1997, 1, 1],
-      age: 28,
-      role: 'USER',
-    } satisfies Awaited<ReturnType<(typeof memberAPI)['getMemberDetail']>>;
-
-    return HttpResponse.json(result);
   }),
 
   http.patch(baseURL('/api/member'), async () => {

--- a/src/mocks/middlewares/withAuth.ts
+++ b/src/mocks/middlewares/withAuth.ts
@@ -1,0 +1,28 @@
+import {
+  HttpResponse,
+  type DefaultBodyType,
+  type HttpResponseResolver,
+  type PathParams,
+} from 'msw';
+import STORAGE_KEYS from '@/constants/storageKeys';
+import { isValidToken } from '@/utils/mswUtils';
+import ERROR_RESPONSES from '@/constants/errorMessages';
+
+/** 로그인이 되어 있지 않다면 401 응답을 하는 미들웨어입니다. */
+function withAuth(
+  resolver: HttpResponseResolver<PathParams, DefaultBodyType, undefined>,
+): HttpResponseResolver<PathParams, DefaultBodyType, undefined> {
+  return async (input) => {
+    const { request } = input;
+
+    const accessToken = request.headers.get(STORAGE_KEYS.accessToken);
+
+    if (!isValidToken(accessToken)) {
+      return new HttpResponse(ERROR_RESPONSES.accessExpired, { status: 401 });
+    }
+
+    return resolver(input);
+  };
+}
+
+export default withAuth;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -25,7 +25,7 @@ const SuspendedPage = () => {
   const navigate = useNavigate();
 
   const birthday = useMemo(
-    () => (member.birthday ? new Date(...member.birthday) : null),
+    () => (member.birthDay ? new Date(...member.birthDay) : null),
     [member],
   );
 

--- a/src/utils/mswUtils.ts
+++ b/src/utils/mswUtils.ts
@@ -9,3 +9,8 @@ export const baseURL = (path: string) => {
 export const isValidToken = (token: string | null) => {
   return token === 'fresh' || token === 'renewed';
 };
+
+/** 브라우저의 URI Path에서 특정 쿼리 스트링을 꺼냅니다. */
+export const getSearchParams = (key: string) => {
+  return new URLSearchParams(window.location.search).get(key);
+};


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #135 

## ✅ 작업 사항
- msw 케이스 분기 처리 방식 변경 (switch 문)
- 로그인 체크하는 withAuth 미들웨어 작성
- queryString 상수 파일 제거

## 👩‍💻 공유 포인트 및 논의 사항
### status 상수
슬랙에서 이야기 나눴던 방식으로 모킹 핸들러를 모두 교체했어요.
만약 상태 코드에 따른 다양한 분기 응답이 필요한 핸들러라면, 다음과 같이 `switch` 문으로 분기 하는 방식이에요.
(fetching 동작에는 200으로 받고, mutation 동작에는 404로 받는 등 유연하게 활용할 수 있을 것 같아요!)

```ts
  http.get(
    baseURL('/api/member'),
    withAuth(async () => {
      await delay(300);

      const status: number = 200;

      switch (status) {
        case 200:
            return HttpResponse.json({
              ... 데이터
            });
        case 404:
          return new HttpResponse(ERROR_RESPONSES.memberNotFound, {
            status,
          });
        default:
          return;
      }
    }),
  ),
```


### withAuth 미들웨어
[msw 공식문서](https://mswjs.io/docs/recipes/higher-order-resolver) 를 참고해서 로컬 스토리지에 액세스 토큰이 'fresh' | 'renewed' 인 경우에만 통과하는 미들웨어를 작성했어요.
만약, 위 경우에 해당하지 않는다면 실제 핸들러를 실행하지 않고 **401 응답**을 내요.
(인가 처리가 들어간 API를 흉내 낼 때 사용하면 좋아 보여요.)

```ts
  http.get(
    baseURL('/api/letter/reply/:letterId'),
    withAuth(async (req) => {
      // 만약 로그인이 안되어있으면 아래 로직은 수행되지 않음
      await delay(300);

      const result: Reply = {
        createdAt: '2024-02-13T16:50:44',
        letterId: Number(req.params.letterId),
        senderNickname: '낯선 고양이123',
        receiverNickname: '낯선 강아지456',
        content: `${req.params.letterId} 번째 편지 입니다. 여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대 부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오`,
        repliedContent: `${req.params.letterId} 번째 편지 답장 입니다.`,
        worryType: 'BREAK_LOVE',
      };

      return HttpResponse.json(result);
    }),
  ),
```

### 런타임에서 모킹 데이터 교체

원래 런타임에서 모킹 데이터를 교체하기 위해서 쿼리 스트링의 키를 `queryString.ts` 파일에 상수로 관리 했었는데요,
생각해보니 각각 핸들러마다 고유한 부분이 될 가능성이 높아서, 그냥 상수화 하지 않고 리터럴 문자열로 넣어도 괜찮을 거 같아요. (대신 모킹 용도가 아닌 쿼리 스트링과 섞이지 않게 접두사로 msw 붙히는 정도? 어떨까요?)

예시:

```ts
  http.get(
    baseURL('/api/letter/reception'),
    withAuth(async () => {
      await delay(1000);

      const itemCount =
        Number(getSearchParams('mswItemCount')) ||
        ReceivedLetterResponse.length;

      return HttpResponse.json(
        ReceivedLetterResponse.slice(0, Number(itemCount)),
      );
    }),
  ),
```

### 사용자 상세 조회 API 필드
사용자 조회 필드 API에 `birthDay` 로 대문자가 들어있고, age의 경우에 `null` 값을 가질 수 있어서 타입을 명시했어요.