### PR TITLE
✨ feat: 편지 쓰기 페이지 API 변동 사항 반영 

### DIFF
--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -8,6 +8,10 @@ const ERROR_RESPONSES = {
   repliedLetterPass: '답장한 편지는 패스할 수 없습니다.',
   alreadyReplyExist: '이미 답장을 완료한 편지입니다.',
   unAnsweredLetterStore: '답장하지 않은 편지는 보관할 수 없습니다.',
+  unSupportExt:
+    '업로드 하신 이미지는 지원하지 않는 파일 형식입니다. 이미지가 png, jpg, jpeg, gif, bmp의 형식인지 확인해주세요.',
+  noExt: '업로드 하신 이미지에 확장자가 존재하지 않습니다.',
+  exceedSendLimit: '하루에 보낼 수 있는 편지를 모두 사용하였습니다.',
 } as const;
 
 export default ERROR_RESPONSES;

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -2,11 +2,11 @@ import { http, HttpResponse, delay } from 'msw';
 import { baseURL, getSearchParams } from '@/utils/mswUtils';
 import { Reception, Reply } from '@/types/letter';
 import ERROR_RESPONSES from '@/constants/errorMessages';
+import withAuth from '../middlewares/withAuth';
 import {
   ReceivedLetterResponse,
   RepliedLettersResponse,
 } from '../datas/letter';
-import withAuth from '../middlewares/withAuth';
 
 const letterHandler = [
   http.get(

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -2,11 +2,11 @@ import { http, HttpResponse, delay } from 'msw';
 import { baseURL, getSearchParams } from '@/utils/mswUtils';
 import { Reception, Reply } from '@/types/letter';
 import ERROR_RESPONSES from '@/constants/errorMessages';
-import withAuth from '../middlewares/withAuth';
 import {
   ReceivedLetterResponse,
   RepliedLettersResponse,
 } from '../datas/letter';
+import withAuth from '../middlewares/withAuth';
 
 const letterHandler = [
   http.get(
@@ -44,7 +44,22 @@ const letterHandler = [
     withAuth(async () => {
       await delay(1000);
 
-      return HttpResponse.json();
+      const status: number = 200;
+
+      switch (status) {
+        case 200:
+          return HttpResponse.json();
+        case 400:
+          return new HttpResponse(ERROR_RESPONSES.exceedSendLimit, {
+            status: 400,
+          });
+        case 415:
+          return new HttpResponse(ERROR_RESPONSES.noExt, {
+            status: 415,
+          });
+        default:
+          break;
+      }
     }),
   ),
 

--- a/src/pages/LetterWritePage/components/LetterPaper.tsx
+++ b/src/pages/LetterWritePage/components/LetterPaper.tsx
@@ -31,7 +31,7 @@ const LetterPaper = ({
       <LetterHeader
         title="From"
         titlePosition="right"
-        nickname={member.nickname}
+        nickname={member.nickname ?? '유저'}
       />
       {watch('image') ? <PolaroidImage /> : <ImageSelect />}
     </LetterCard>

--- a/src/pages/LetterWritePage/components/LetterPaper.tsx
+++ b/src/pages/LetterWritePage/components/LetterPaper.tsx
@@ -1,6 +1,9 @@
 import { useFormContext } from 'react-hook-form';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import LetterLengthDate from '@/components/LetterLengthDate';
 import LetterCard from '@/components/LetterCard';
+import memberOptions from '@/api/member/queryOptions';
+import LetterHeader from '@/components/LetterHeader';
 import { type WriteInputs } from '..';
 import { BottomSheetProps } from './LetterWriteContent';
 import {
@@ -15,6 +18,7 @@ const LetterPaper = ({
   toggleBottomSheet,
 }: BottomSheetProps) => {
   const { watch } = useFormContext<WriteInputs>();
+  const { data: member } = useSuspenseQuery(memberOptions.detail());
 
   return (
     <LetterCard isOpen={true}>
@@ -24,6 +28,11 @@ const LetterPaper = ({
       />
       <LetterContent />
       <LetterLengthDate letterLength={watch('content').length} />
+      <LetterHeader
+        title="From"
+        titlePosition="right"
+        nickname={member.nickname}
+      />
       {watch('image') ? <PolaroidImage /> : <ImageSelect />}
     </LetterCard>
   );

--- a/src/pages/LetterWritePage/components/inputs/ImageSelect.tsx
+++ b/src/pages/LetterWritePage/components/inputs/ImageSelect.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form';
+import React from 'react';
 import ImageUploadButton from '@/components/ImageUploadButton';
 import { type WriteInputs } from '../..';
 

--- a/src/pages/LetterWritePage/index.tsx
+++ b/src/pages/LetterWritePage/index.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { useForm, FormProvider, FieldError } from 'react-hook-form';
+import { useForm, FormProvider } from 'react-hook-form';
 import { toast } from 'react-toastify';
 import { useEffect } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -12,8 +12,8 @@ import Header from '@/components/Header';
 import { letterWrite } from '@/constants/schemaLiteral';
 import letterAPI from '@/api/letter/apis';
 import ERROR_RESPONSES from '@/constants/errorMessages';
-import { LetterWriteContent, LetterWriteBottom } from './components';
 import style from './styles';
+import { LetterWriteContent, LetterWriteBottom } from './components';
 
 const L = letterWrite;
 
@@ -67,7 +67,7 @@ const LetterWritePage = () => {
   const onSubmit = async (data: WriteInputs) => {
     try {
       await postLetter(data);
-      toast.success('편지를 성공적으로 작성했어요!', {
+      toast.success('편지를 바다에 띄어보냈어요', {
         position: 'bottom-center',
         autoClose: 1500,
       });
@@ -96,18 +96,25 @@ const LetterWritePage = () => {
   };
 
   useEffect(() => {
-    const showErrorToast = (error: FieldError) => {
-      if ('message' in error) {
-        toast.warn(error.message, {
-          position: 'bottom-center',
-          autoClose: 1500,
-        });
-      }
-    };
-
-    Object.values(errors).forEach((error) => {
-      showErrorToast(error as FieldError);
-    });
+    if (errors.worryType || errors.gender || errors.age) {
+      toast.warn('보낼 사람을 선택하세요', {
+        position: 'bottom-center',
+        autoClose: 1500,
+        hideProgressBar: true,
+      });
+    } else if (errors.content) {
+      toast.warn('내용을 입력하세요', {
+        position: 'bottom-center',
+        autoClose: 1500,
+        hideProgressBar: true,
+      });
+    } else if (errors.image) {
+      toast.warn(errors.image.message?.toString(), {
+        position: 'bottom-center',
+        autoClose: 1500,
+        hideProgressBar: true,
+      });
+    }
   }, [errors]);
 
   return (

--- a/src/pages/LetterWritePage/index.tsx
+++ b/src/pages/LetterWritePage/index.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
-import { useForm, FormProvider } from 'react-hook-form';
+import { useForm, FormProvider, FieldError } from 'react-hook-form';
 import { toast } from 'react-toastify';
+import { useEffect } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import z from 'zod';
 import { useMutation } from '@tanstack/react-query';
@@ -11,8 +12,8 @@ import Header from '@/components/Header';
 import { letterWrite } from '@/constants/schemaLiteral';
 import letterAPI from '@/api/letter/apis';
 import ERROR_RESPONSES from '@/constants/errorMessages';
-import style from './styles';
 import { LetterWriteContent, LetterWriteBottom } from './components';
+import style from './styles';
 
 const L = letterWrite;
 
@@ -56,7 +57,7 @@ const LetterWritePage = () => {
 
   const {
     handleSubmit,
-    // formState: { errors },
+    formState: { errors },
   } = methods;
 
   const { mutateAsync: postLetter, isPending } = useMutation({
@@ -66,6 +67,11 @@ const LetterWritePage = () => {
   const onSubmit = async (data: WriteInputs) => {
     try {
       await postLetter(data);
+      toast.success('편지를 성공적으로 작성했어요!', {
+        position: 'bottom-center',
+        autoClose: 1500,
+      });
+      navigate(ROUTER_PATHS.ROOT);
     } catch (error) {
       if (isAxiosError(error)) {
         if (
@@ -88,6 +94,21 @@ const LetterWritePage = () => {
       }
     }
   };
+
+  useEffect(() => {
+    const showErrorToast = (error: FieldError) => {
+      if ('message' in error) {
+        toast.warn(error.message, {
+          position: 'bottom-center',
+          autoClose: 1500,
+        });
+      }
+    };
+
+    Object.values(errors).forEach((error) => {
+      showErrorToast(error as FieldError);
+    });
+  }, [errors]);
 
   return (
     <FormProvider {...methods}>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #159 

## ✅ 작업 사항

편지 쓰기 페이지 API 변동 사항을 반영했어요.
하면서 토스트도 사용해봤는데 나중에 다시 자세하게 적용시켜야 될 것 같네요.

### 편지 작성 성공

편지가 성공적으로 보내지면 메인페이지 이동하고 토스트 창을 띄웠어요.

```tsx
    try {
      await postLetter(data);
      toast.success('편지를 바다에 띄어보냈어요', {
        position: 'bottom-center',
        autoClose: 1500,
      });
      navigate(ROUTER_PATHS.ROOT);
    } 
```

<img width="410" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/9b29f754-dde5-44de-aecd-2a91ae49a54b">
 
### 편지 작성 예외

#### 400번

하루에 보낼 양을 넘을 경우 메인페이지 이동과 토스트를 보여줍니다.

```tsx
        } else if (error.response?.data === ERROR_RESPONSES.exceedSendLimit) {
          toast.error(error.response?.data, {
            position: 'bottom-center',
          });
          navigate(ROUTER_PATHS.ROOT);
        } 
```

<img width="384" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/42d9bc2e-b479-4713-8a9e-79706cb48b6f">

#### 415번

이미지 형식이 잘못된 경우는 토스트만 보여줬습니다.

```tsx
        if (
          error.response?.data === ERROR_RESPONSES.unSupportExt ||
          error.response?.data === ERROR_RESPONSES.noExt
        ) {
          toast.error(error.response?.data, {
            position: 'bottom-center',
          });
```

<img width="408" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/ba06a481-72e4-4593-9359-5e93cb78f5dc">

### 폼 유효성검사

이건 나중에 디자인 반영 사항 구현할 때 자세히 할 예정입니다.

<img width="431" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/ecdc3f7f-386c-4995-ba23-fefc52b07f1c">

<img width="373" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/1b448c2f-d765-4f77-92fd-a5e9351abc31">

### 편지 보내는 사람 닉네임

편지를 보내는 사람의 닉네임이 필요해서 useSuspenseQuery 를 사용했고 닉네임이 null인 경우가 있어서 그땐 유저 라고 표시했습니다.

```tsx
const { data: member } = useSuspenseQuery(memberOptions.detail());
// 생략...
nickname={member.nickname ?? '유저'}
```

<img width="172" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/b7e565de-a19c-4879-a62a-17fb1a6cebac">


## 👩‍💻 공유 포인트 및 논의 사항
