### PR TITLE
✨ feat: Tooltip 컴포넌트에 mountKey 추가

### DIFF
--- a/src/components/Tooltip/index.stories.tsx
+++ b/src/components/Tooltip/index.stories.tsx
@@ -29,6 +29,7 @@ export const Primary: Story = {
     side: 'bottom',
     align: 'end',
     delay: 1000,
+    mountKey: undefined,
     triggerContent: (
       <IconButton>
         <SoundOff color="white" />

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import * as T from '@radix-ui/react-tooltip';
 import useTimeout from '@/hooks/useTimeout';
@@ -10,6 +10,8 @@ interface TooltipProps {
   side?: 'left' | 'top' | 'right' | 'bottom';
   /** 화살표 모양의 위치를 지정합니다. */
   align?: 'start' | 'center' | 'end';
+  /** 마운트시 최초로 툴팁을 한 번만 보여주고 싶을 때, sessionStorage에 저장할 키를 지정합니다. (없다면 항시 보여줍니다.) */
+  mountKey?: string;
   /** 마운트시 최초로 툴팁을 보여줄 시간을 지정합니다. */
   delay?: number;
   /** 툴팁을 보여줄 트리거 컨텐츠를 지정합니다. */
@@ -23,12 +25,23 @@ const Tooltip = ({
   side = 'bottom',
   align = 'center',
   delay = 0,
+  mountKey,
   triggerContent,
   children,
 }: TooltipProps) => {
-  const [isOpen, setIsOpen] = useState(delay > 0);
+  const KEY = `tooltip-${mountKey}`;
 
-  useTimeout(() => setIsOpen(false), delay);
+  const [isOpen, setIsOpen] = useState(
+    delay <= 0 ? false : mountKey && sessionStorage.getItem(KEY) ? false : true,
+  );
+
+  useEffect(() => {
+    sessionStorage.setItem(KEY, 'true');
+  }, []);
+
+  useTimeout(() => {
+    setIsOpen(false);
+  }, delay);
 
   return (
     <T.Provider>

--- a/src/pages/MainPage/components/WritingButton/index.tsx
+++ b/src/pages/MainPage/components/WritingButton/index.tsx
@@ -12,6 +12,8 @@ const WritingButton = () => {
 
   return (
     <Tooltip
+      delay={3000}
+      mountKey="writingButton"
       triggerContent={
         <Link
           css={[iconButtonStyles.button('header', 'r8'), styles.button]}
@@ -23,7 +25,6 @@ const WritingButton = () => {
         </Link>
       }
       align="start"
-      delay={1000}
     >
       <p>편지지는 </p>
       <p>하루마다 충전 돼요</p>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #164 

## ✅ 작업 사항
툴팁 컴포넌트 마운트 시 단 한번만 출력하는 기능(mountKey 추가)

![툴팁 mount](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/74bdc86c-9aba-468c-8f5a-3a629a3e166f)


## 👩‍💻 공유 포인트 및 논의 사항
Tooltip 컴포넌트의 mountKey로 키 값을 넘겨주면, 마운트 시 단 한번만 툴팁을 보여줘요. (세션스토리지에 기록)
주로 온보딩 쪽에서 많이 사용될 것 같아요.