### PR TITLE
✨ refactor: 이미지 삽입으로 인한 API 변동 사항 반영

### DIFF
--- a/src/mocks/datas/letter.ts
+++ b/src/mocks/datas/letter.ts
@@ -278,7 +278,8 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'WORK',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
   {
     createdAt: '2024-02-05T15:40:44',
@@ -294,7 +295,8 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'LOVE',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
   {
     createdAt: '2024-02-05T15:40:44',
@@ -310,7 +312,8 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'LOVE',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
   {
     createdAt: '2024-02-05T15:40:44',
@@ -326,7 +329,8 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'LOVE',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
   {
     createdAt: '2024-02-05T15:40:44',
@@ -342,7 +346,8 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'LOVE',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
   {
     createdAt: '2024-02-05T15:40:44',
@@ -358,7 +363,8 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'LOVE',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
   {
     createdAt: '2024-02-05T15:40:44',
@@ -374,7 +380,8 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'LOVE',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
   {
     createdAt: '2024-02-05T15:40:44',
@@ -390,7 +397,8 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'LOVE',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
   {
     createdAt: '2024-02-05T15:40:44',
@@ -406,7 +414,8 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'LOVE',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
   {
     createdAt: '2024-02-05T15:40:44',
@@ -422,6 +431,7 @@ export const RepliedLettersResponse = [
     content: '안녕',
     repliedContent: '안녕하세요!',
     worryType: 'LOVE',
-    imagePath: null,
+    sendImagePath: null,
+    replyImagePath: null,
   },
 ] satisfies Awaited<ReturnType<(typeof letterAPI)['getRepliedLetters']>>;

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -2,11 +2,11 @@ import { http, HttpResponse, delay } from 'msw';
 import { baseURL, getSearchParams } from '@/utils/mswUtils';
 import { Reception, Reply } from '@/types/letter';
 import ERROR_RESPONSES from '@/constants/errorMessages';
-import withAuth from '../middlewares/withAuth';
 import {
   ReceivedLetterResponse,
   RepliedLettersResponse,
 } from '../datas/letter';
+import withAuth from '../middlewares/withAuth';
 
 const letterHandler = [
   http.get(
@@ -157,8 +157,9 @@ const letterHandler = [
         content: `${req.params.letterId} 번째 편지 입니다. 여기 거 다 남겨두고서 혹시겨두고서 혹시나 기대도 포기하려 하오 그대 부디 잘 지내시오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오 좋은 사람 만나오 사는 동안 날 잊고 사시오 진정 행복하길 바라겠소 이 맘만 가져가오 기나긴 그대 침묵을 이별로 받아두겠소 행여 이 맘 다칠까 근심은 접어두오 오 사랑한 사람이여 더 이상 못보아도 사실 그대 있음으로 힘겨운 날들을 견뎌 왔음에 감사하오`,
         repliedContent: `${req.params.letterId} 번째 편지 답장 입니다.`,
         worryType: 'BREAK_LOVE',
-        // imagePath: null,
-        imagePath:
+        sendImagePath:
+          'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_1280.jpg',
+        replyImagePath:
           'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_1280.jpg',
       };
 

--- a/src/mocks/handlers/letter.ts
+++ b/src/mocks/handlers/letter.ts
@@ -2,11 +2,11 @@ import { http, HttpResponse, delay } from 'msw';
 import { baseURL, getSearchParams } from '@/utils/mswUtils';
 import { Reception, Reply } from '@/types/letter';
 import ERROR_RESPONSES from '@/constants/errorMessages';
+import withAuth from '../middlewares/withAuth';
 import {
   ReceivedLetterResponse,
   RepliedLettersResponse,
 } from '../datas/letter';
-import withAuth from '../middlewares/withAuth';
 
 const letterHandler = [
   http.get(
@@ -110,6 +110,10 @@ const letterHandler = [
         case 400:
           return new HttpResponse(ERROR_RESPONSES.alreadyReplyExist, {
             status: 400,
+          });
+        case 415:
+          return new HttpResponse(ERROR_RESPONSES.unSupportExt, {
+            status: 415,
           });
         default:
           break;

--- a/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReceivedLetter/index.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import TagList from '@/components/TagList';
@@ -13,11 +14,10 @@ import LoadingSpinner from '@/components/LoadingSpinner';
 import { ROUTER_PATHS } from '@/router';
 import letterOptions from '@/api/letter/queryOptions';
 import ERROR_RESPONSES from '@/constants/errorMessages';
-import ReceptionPolaroid from '../components/ReceptionPolaroid';
-import LetterContent from '../components/LetterContent';
 import useLetterWithTags from '../hooks/useLetterWithTags';
+import LetterContent from '../components/LetterContent';
+import ReceptionPolaroid from '../components/ReceptionPolaroid';
 import style from './styles';
-
 interface ReceivedLetterProps {
   letterId: number;
   onNext: () => void;
@@ -44,7 +44,10 @@ const ReceivedLetter = ({ letterId, onNext }: ReceivedLetterProps) => {
         (error.response?.data === ERROR_RESPONSES.accessDeniedLetter ||
           error.response?.data === ERROR_RESPONSES.repliedLetterPass)
       ) {
-        console.error(error.response?.data);
+        toast.error(error.response?.data, {
+          position: 'bottom-center',
+        });
+        navigate(ROUTER_PATHS.ROOT);
       } else {
         throw error;
       }

--- a/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/ReplyToLetter/index.tsx
@@ -1,5 +1,6 @@
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { zodResolver } from '@hookform/resolvers/zod';
 import z from 'zod';
@@ -20,10 +21,10 @@ import ImageUploadButton from '@/components/ImageUploadButton';
 import PolaroidModal from '@/components/PolaroidModal';
 import IconButton from '@/components/IconButton';
 import { TrashCan } from '@/assets/icons';
-import LetterContent from '../components/LetterContent';
 import useLetterWithTags from '../hooks/useLetterWithTags';
-import style from './styles';
+import LetterContent from '../components/LetterContent';
 import ReceivedAccordionLetter from './ReceivedAccordionLetter';
+import style from './styles';
 
 const L = letterWrite;
 
@@ -84,12 +85,23 @@ const ReplyToLetter = ({ letterId, onPrev }: ReplyToLetterProps) => {
       queryClient.invalidateQueries({ queryKey: letterOptions.all });
       navigate(ROUTER_PATHS.ROOT);
     } catch (error) {
-      if (
-        isAxiosError(error) &&
-        (error.response?.data === ERROR_RESPONSES.accessDeniedLetter ||
-          error.response?.data === ERROR_RESPONSES.alreadyReplyExist)
-      ) {
-        console.error(error.response?.data);
+      if (isAxiosError(error)) {
+        if (
+          error.response?.data === ERROR_RESPONSES.accessDeniedLetter ||
+          error.response?.data === ERROR_RESPONSES.alreadyReplyExist
+        ) {
+          toast.error(error.response?.data, {
+            position: 'bottom-center',
+          });
+          navigate(ROUTER_PATHS.ROOT);
+        } else if (
+          error.response?.data === ERROR_RESPONSES.unSupportExt ||
+          error.response?.data === ERROR_RESPONSES.noExt
+        ) {
+          toast.error(error.response?.data, {
+            position: 'bottom-center',
+          });
+        }
       } else {
         throw error;
       }
@@ -166,6 +178,7 @@ const ReplyToLetter = ({ letterId, onPrev }: ReplyToLetterProps) => {
       </form>
       {/** 임시 에러 출력용 */}
       {errors.replyContent && <p>{errors.replyContent.message}</p>}
+      {errors.image && <p>{errors.image.message?.toString()}</p>}
     </LetterContent>
   );
 };

--- a/src/pages/LetterReplyPage/replyLetter/index.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.tsx
@@ -1,7 +1,9 @@
 import LetterCard from '@/components/LetterCard';
 import { formatDate } from '@/utils/dateUtils';
-import LetterContent from '../components/LetterContent';
+import PolaroidModal from '@/components/PolaroidModal';
+import Button from '@/components/Button';
 import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
+import LetterContent from '../components/LetterContent';
 
 interface ReplyLetterProps {
   letterId: number;
@@ -18,6 +20,17 @@ const ReplyLetter = ({ letterId }: ReplyLetterProps) => {
         date={formatDate(new Date(replyLetter.repliedAt))}
         sender={replyLetter.senderNickname}
       />
+      {replyLetter.replyImagePath !== null && (
+        <PolaroidModal
+          topPosition={4.2}
+          leftPosition={1.2}
+          img={replyLetter.replyImagePath}
+        >
+          <Button variant="secondary" size="sm">
+            닫기
+          </Button>
+        </PolaroidModal>
+      )}
     </LetterCard>
   );
 };

--- a/src/pages/LetterReplyPage/sentLetter/index.tsx
+++ b/src/pages/LetterReplyPage/sentLetter/index.tsx
@@ -8,8 +8,8 @@ import PolaroidModal from '@/components/PolaroidModal';
 import TagList from '@/components/TagList';
 import Button from '@/components/Button';
 import { formatDate } from '@/utils/dateUtils';
-import LetterContent from '../components/LetterContent';
 import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
+import LetterContent from '../components/LetterContent';
 import style from './styles';
 interface SentLetterProps {
   letterId: number;
@@ -50,11 +50,11 @@ const SentLetter = ({ letterId }: SentLetterProps) => {
               date={formatDate(new Date(replyLetter.createdAt))}
               sender={replyLetter.receiverNickname}
             />
-            {replyLetter.imagePath !== null && (
+            {replyLetter.sendImagePath !== null && (
               <PolaroidModal
                 topPosition={4.2}
                 leftPosition={1.2}
-                img={replyLetter.imagePath}
+                img={replyLetter.sendImagePath}
               >
                 <Button variant="secondary" size="sm">
                   닫기

--- a/src/pages/LetterReplyPage/sentLetter/styles.ts
+++ b/src/pages/LetterReplyPage/sentLetter/styles.ts
@@ -9,7 +9,7 @@ const style = {
     align-items: center;
     padding: 1rem 1.25rem;
     border-radius: 0.5rem;
-    background: #fff;
+    background: #f2eade;
     cursor: pointer;
 
     :hover {
@@ -17,7 +17,7 @@ const style = {
     }
   `,
   text: css`
-    color: ${COLORS.gray4};
+    color: ${COLORS.letterChip2};
     ${textStyles.b4m}
   `,
   header: css`

--- a/src/types/letter.ts
+++ b/src/types/letter.ts
@@ -36,5 +36,6 @@ export type Reply = {
   content: string;
   repliedContent: string;
   worryType: Worry;
-  imagePath: string | null;
+  sendImagePath: string | null;
+  replyImagePath: string | null;
 };


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #172 

## ✅ 작업 사항

### 답장 예외 처리

reception 페이지에서 답장을 보낼 때, 사진에 대한 예외 처리를 추가하였습니다.

<img width="378" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/34f4b4ad-3a4d-436c-b7cc-f43b6368580c">

```tsx
    } catch (error) {
      if (isAxiosError(error)) {
        if (
          error.response?.data === ERROR_RESPONSES.accessDeniedLetter ||
          error.response?.data === ERROR_RESPONSES.alreadyReplyExist
        ) {
          toast.error(error.response?.data, {
            position: 'bottom-center',
          });
          navigate(ROUTER_PATHS.ROOT);
        } else if (
          error.response?.data === ERROR_RESPONSES.unSupportExt ||
          error.response?.data === ERROR_RESPONSES.noExt
        ) {
          toast.error(error.response?.data, {
            position: 'bottom-center',
          });
        }
      } else {
        throw error;
      }
    }
```

### Reply 타입

API 변동 사항에 맞게 타입을 수정하였고(sendImagePath, replyImagePath) Reply 페이지에도 반영했습니다.

```tsx
export type Reply = {
  createdAt: string;
  repliedAt: string;
  letterId: number;
  letterTag: LetterTag;
  senderNickname: string;
  receiverNickname: string;
  content: string;
  repliedContent: string;
  worryType: Worry;
  sendImagePath: string | null;
  replyImagePath: string | null;
};
```

## 👩‍💻 공유 포인트 및 논의 사항
