### PR TITLE
✨ feat: 내게 온 답장 페이지 바텀시트, 토스트 구현

### DIFF
--- a/src/pages/LetterReplyPage/components/BottomButton.tsx
+++ b/src/pages/LetterReplyPage/components/BottomButton.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { css } from '@emotion/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
@@ -10,12 +11,15 @@ import letterOptions from '@/api/letter/queryOptions';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import Tooltip from '@/components/Tooltip';
 import ERROR_RESPONSES from '@/constants/errorMessages';
+import BottomSheet from '@/components/BottomSheet';
+import useBoolean from '@/hooks/useBoolean';
 
 interface BottomButtonProps {
   letterId: number;
 }
 
 const BottomButton = ({ letterId }: BottomButtonProps) => {
+  const { value, on, off } = useBoolean(false);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
@@ -27,7 +31,10 @@ const BottomButton = ({ letterId }: BottomButtonProps) => {
     try {
       await patchStorage(letterId);
       queryClient.invalidateQueries({ queryKey: letterOptions.all });
-      navigate(ROUTER_PATHS.ROOT);
+      toast.success('편지를 보관함에 넣었어요', {
+        autoClose: 1500,
+        position: 'bottom-center',
+      });
     } catch (error) {
       if (
         isAxiosError(error) &&
@@ -42,31 +49,53 @@ const BottomButton = ({ letterId }: BottomButtonProps) => {
   };
 
   return (
-    <Navbar css={styles.navbar}>
-      <Button
-        variant="secondary"
-        size="sm"
-        onClick={() => navigate(ROUTER_PATHS.ROOT)}
-      >
-        닫기
-      </Button>
-      <Tooltip
-        side="top"
-        delay={10000}
-        triggerContent={
-          <Button
-            disabled={isPending}
-            variant="primary"
-            size="sm"
-            onClick={handleStorageLetter}
-          >
-            {isPending ? <LoadingSpinner /> : <>보관하기</>}
+    <>
+      <Navbar css={styles.navbar}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => navigate(ROUTER_PATHS.ROOT)}
+        >
+          닫기
+        </Button>
+        <Tooltip
+          side="top"
+          delay={10000}
+          triggerContent={
+            <Button
+              disabled={isPending}
+              variant="primary"
+              size="sm"
+              onClick={on}
+            >
+              {isPending ? <LoadingSpinner /> : <>보관하기</>}
+            </Button>
+          }
+        >
+          편지를 보관하여 간직해보세요
+        </Tooltip>
+      </Navbar>
+      <BottomSheet open={value} onOpen={on} onClose={off}>
+        <BottomSheet.Title>편지를 보관함에 저장할까요?</BottomSheet.Title>
+        <BottomSheet.Description>
+          편지를 보관함에 저장해 언제든지 볼 수 있어요.
+        </BottomSheet.Description>
+        <BottomSheet.ButtonSection>
+          <Button variant="cancel" onClick={off}>
+            취소
           </Button>
-        }
-      >
-        편지를 보관하여 간직해보세요
-      </Tooltip>
-    </Navbar>
+          <Button
+            variant="primary"
+            onClick={() => {
+              off();
+              handleStorageLetter();
+            }}
+          >
+            보관하기
+          </Button>
+        </BottomSheet.ButtonSection>
+      </BottomSheet>
+    </>
   );
 };
 

--- a/src/pages/LetterReplyPage/components/BottomButton.tsx
+++ b/src/pages/LetterReplyPage/components/BottomButton.tsx
@@ -4,7 +4,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import Navbar from '@/components/Navbar';
 import Button from '@/components/Button';
-import { TreasureChestOutline } from '@/assets/icons';
 import { ROUTER_PATHS } from '@/constants/routerPaths';
 import letterAPI from '@/api/letter/apis';
 import letterOptions from '@/api/letter/queryOptions';
@@ -61,18 +60,11 @@ const BottomButton = ({ letterId }: BottomButtonProps) => {
             size="sm"
             onClick={handleStorageLetter}
           >
-            {isPending ? (
-              <LoadingSpinner />
-            ) : (
-              <>
-                <TreasureChestOutline />
-                보관하기
-              </>
-            )}
+            {isPending ? <LoadingSpinner /> : <>보관하기</>}
           </Button>
         }
       >
-        편지를 보관하면 <br /> 시간이 지나도 사라지지 않아요
+        편지를 보관하여 간직해보세요
       </Tooltip>
     </Navbar>
   );

--- a/src/pages/LetterReplyPage/components/ReplyHeader.tsx
+++ b/src/pages/LetterReplyPage/components/ReplyHeader.tsx
@@ -31,7 +31,6 @@ const ReplyHeader = ({ letterId }: ReplyHeaderProps) => {
           <Tooltip
             delay={3000}
             align="start"
-            mountKey="replyTimeChip"
             triggerContent={
               <div>
                 <DetailTimeChip type="day" createdAt={replyLetter.createdAt} />

--- a/src/pages/LetterReplyPage/components/ReplyHeader.tsx
+++ b/src/pages/LetterReplyPage/components/ReplyHeader.tsx
@@ -5,6 +5,7 @@ import { CaretLeft, Siren } from '@/assets/icons';
 import IconButton from '@/components/IconButton';
 import { ROUTER_PATHS } from '@/constants/routerPaths';
 import DetailTimeChip from '@/components/DetailTimeChip';
+import Tooltip from '@/components/Tooltip';
 import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
 
 interface ReplyHeaderProps {
@@ -27,7 +28,18 @@ const ReplyHeader = ({ letterId }: ReplyHeaderProps) => {
             color="white"
             onClick={() => navigate(ROUTER_PATHS.ROOT)}
           />
-          <DetailTimeChip type="day" createdAt={replyLetter.createdAt} />
+          <Tooltip
+            delay={3000}
+            align="start"
+            mountKey="replyTimeChip"
+            triggerContent={
+              <div>
+                <DetailTimeChip type="day" createdAt={replyLetter.createdAt} />
+              </div>
+            }
+          >
+            내게 온 답장은 7일이 지나면 사라져요
+          </Tooltip>
         </>
       }
       rightContent={

--- a/src/pages/LetterReplyPage/replyLetter/index.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.tsx
@@ -1,9 +1,13 @@
+import { toast } from 'react-toastify';
+import axios from 'axios';
 import LetterCard from '@/components/LetterCard';
 import { formatDate } from '@/utils/dateUtils';
 import PolaroidModal from '@/components/PolaroidModal';
 import Button from '@/components/Button';
-import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
+import IconButton from '@/components/IconButton';
+import { Download } from '@/assets/icons';
 import LetterContent from '../components/LetterContent';
+import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
 
 interface ReplyLetterProps {
   letterId: number;
@@ -11,6 +15,27 @@ interface ReplyLetterProps {
 
 const ReplyLetter = ({ letterId }: ReplyLetterProps) => {
   const { replyLetter } = useLetterReplyWithTag(letterId);
+
+  const handleDownload = async () => {
+    const response = await axios.get(replyLetter.replyImagePath!, {
+      responseType: 'blob',
+    });
+
+    const url = window.URL.createObjectURL(new Blob([response.data]));
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'image.jpg';
+    document.body.appendChild(link);
+    link.click();
+
+    window.URL.revokeObjectURL(url);
+
+    toast.success('사진이 저장됐어요', {
+      position: 'bottom-center',
+      autoClose: 1500,
+    });
+  };
 
   return (
     <LetterCard isOpen={true}>
@@ -25,6 +50,11 @@ const ReplyLetter = ({ letterId }: ReplyLetterProps) => {
           topPosition={5.2}
           leftPosition={1.2}
           img={replyLetter.replyImagePath}
+          headerRightContent={
+            <IconButton onClick={handleDownload}>
+              <Download color="white" height={20} width={20} />
+            </IconButton>
+          }
         >
           <Button variant="secondary" size="sm">
             닫기

--- a/src/pages/LetterReplyPage/sentLetter/styles.ts
+++ b/src/pages/LetterReplyPage/sentLetter/styles.ts
@@ -13,7 +13,7 @@ const style = {
     cursor: pointer;
 
     :hover {
-      background: ${COLORS.gray6};
+      background: #e5dfcc;
     }
   `,
   text: css`


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #193 

## ✅ 작업 사항

### 툴팁

<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/88929a47-154e-49e7-b34e-6860834c06d6">

### 이미지 저장 버튼

<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/e1217369-1caa-4b56-8074-bf1001bb2a47">

### 보관하기 바텀시트, 토스트

<img width="399" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/4e7186a8-3ce8-4fce-8d1e-22441f2b23ca">
<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/6845b6bf-a0f9-4dec-82b1-2290087d3987">


## 👩‍💻 공유 포인트 및 논의 사항

아마 보관하고 토스트창? 안뜬다는 말씀 같은데 이 부분 구현했습니다.

<img width="269" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/5da6facb-07ea-4df1-b73f-526b7d1f51b9">

