### PR TITLE
🚑 fix: 발표 전 피드백 내용 반영

### DIFF
--- a/src/components/ErrorBoundary/fallback/RootApiFallback.tsx
+++ b/src/components/ErrorBoundary/fallback/RootApiFallback.tsx
@@ -12,7 +12,8 @@ const RootApiFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
     !isAxiosError(error) ||
     error.response?.data === ERROR_RESPONSES.accessExpired ||
     error.response?.data === ERROR_RESPONSES.reissueFailed ||
-    error.response?.data === ERROR_RESPONSES.authenticationEntryPoint;
+    error.response?.data === ERROR_RESPONSES.authenticationEntryPoint ||
+    error.response?.data === ERROR_RESPONSES.memberNotFound;
 
   useEffect(() => {
     if (shouldSkip) {

--- a/src/components/ErrorBoundary/fallback/RootUnknownFallback.tsx
+++ b/src/components/ErrorBoundary/fallback/RootUnknownFallback.tsx
@@ -15,6 +15,7 @@ const RootUnknownFallback = ({ error }: FallbackProps) => {
   const shouldSkip =
     isAxiosError(error) &&
     (error.response?.data === ERROR_RESPONSES.reissueFailed ||
+      error.response?.data === ERROR_RESPONSES.memberNotFound ||
       error.response?.data === ERROR_RESPONSES.authenticationEntryPoint);
 
   useEffect(() => {

--- a/src/pages/LetterReceptionPage/OnboardingReception/index.tsx
+++ b/src/pages/LetterReceptionPage/OnboardingReception/index.tsx
@@ -9,8 +9,7 @@ import {
 } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import Header from '@/components/Header';
-import { CaretLeft, Siren } from '@/assets/icons';
-import IconButton from '@/components/IconButton';
+import { CaretLeft } from '@/assets/icons';
 import LetterCard from '@/components/LetterCard';
 import LetterHeader from '@/components/LetterHeader';
 import Navbar from '@/components/Navbar';
@@ -92,11 +91,6 @@ const OnboardingReception = () => {
             strokeWidth={2.5}
             onClick={handleNavigateToRoot}
           />
-        }
-        rightContent={
-          <IconButton>
-            <Siren css={styles.icon} />
-          </IconButton>
         }
       />
       <motion.main

--- a/src/pages/LetterWritePage/index.tsx
+++ b/src/pages/LetterWritePage/index.tsx
@@ -4,7 +4,7 @@ import { toast } from 'react-toastify';
 import { useEffect } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import z from 'zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { ROUTER_PATHS } from '@/constants/routerPaths';
 import { letterWrite } from '@/constants/schemaLiteral';
@@ -13,6 +13,7 @@ import ERROR_RESPONSES from '@/constants/errorMessages';
 import BottomSheet from '@/components/BottomSheet';
 import useBoolean from '@/hooks/useBoolean';
 import Button from '@/components/Button';
+import letterOptions from '@/api/letter/queryOptions';
 import LetteWriteHeader from './components/LetterWriteHeader';
 import { LetterWriteContent, LetterWriteBottom } from './components';
 import style from './styles';
@@ -67,6 +68,7 @@ const LetterWritePage = () => {
   const { mutateAsync: postLetter, isPending } = useMutation({
     mutationFn: letterAPI.postLetter,
   });
+  const queryClient = useQueryClient();
 
   const onSubmit = async (data: WriteInputs) => {
     try {
@@ -75,6 +77,7 @@ const LetterWritePage = () => {
         position: 'bottom-center',
         autoClose: 1500,
       });
+      queryClient.invalidateQueries({ queryKey: letterOptions.all });
       navigate(ROUTER_PATHS.ROOT);
     } catch (error) {
       if (isAxiosError(error)) {

--- a/src/pages/MainPage/hooks/useLetterSlides.ts
+++ b/src/pages/MainPage/hooks/useLetterSlides.ts
@@ -24,8 +24,7 @@ const useLetterSlides = () => {
     REPLIES_PER_SLIDE,
   );
 
-  const slideLength = Math.max(refinedReceptions.length, refinedReplies.length);
-  const slides = Array.from({ length: slideLength }, (_, idx) => ({
+  const slides = Array.from({ length: MAX_SLIDES }, (_, idx) => ({
     id: idx + 1,
     receptions: refinedReceptions[idx] || [],
     replies: refinedReplies[idx] || [],

--- a/src/pages/MainPage/hooks/useLetterSlides.ts
+++ b/src/pages/MainPage/hooks/useLetterSlides.ts
@@ -11,7 +11,10 @@ const REPLIES_PER_SLIDE = 2;
 
 const useLetterSlides = () => {
   const [{ data: receptions }, { data: replies }] = useSuspenseQueries({
-    queries: [letterOptions.reception(), letterOptions.reply()],
+    queries: [
+      { ...letterOptions.reception(), refetchInterval: 60000 },
+      { ...letterOptions.reply(), refetchInterval: 60000 },
+    ],
   });
 
   const refinedReceptions = chunkArray(

--- a/src/pages/OnboardingPage/steps/LastStep.tsx
+++ b/src/pages/OnboardingPage/steps/LastStep.tsx
@@ -6,7 +6,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { css } from '@emotion/react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import Button from '@/components/Button';
 import textStyles from '@/styles/textStyles';
@@ -14,6 +14,7 @@ import { ROUTER_PATHS } from '@/constants/routerPaths';
 import memberAPI from '@/api/member/apis';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import ERROR_RESPONSES from '@/constants/errorMessages';
+import memberOptions from '@/api/member/queryOptions';
 import StepTemplate from '../components/StepTemplate';
 import { Inputs, formLiteral } from '../hooks/useOnboardingForm';
 
@@ -27,6 +28,8 @@ const LastStep = () => {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: memberAPI.patchMemberDetail,
   });
+
+  const queryClient = useQueryClient();
 
   const onSubmit: SubmitHandler<Inputs> = async (data) => {
     const year = data.birthday.year
@@ -49,6 +52,7 @@ const LastStep = () => {
         birthday,
       });
 
+      queryClient.invalidateQueries(memberOptions.detail());
       navigate(ROUTER_PATHS.ROOT);
 
       toast.success('프로필이 완성됐어요', {


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #196 

## ✅ 작업 사항
- 메인 페이지 슬라이드 기본 4개로 하기
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/3a59e6a1-448c-462b-a567-5e91a7d9e95c)

- 존재하지 않는 회원입니다. 응답 받으면 임시로 로그인 페이지로 이동
  - (우선 임시로 해두고, 추후에 백엔드 팀원분들과 에러 핸들링 관련해서 이야기 나눠보면 좋을 것 같아요!)

- 온보딩 편지 신고 버튼 제거
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/cbffef0e-168b-4bbf-ba63-b61a0ac19d1f)

- 편지 전송 후 Letter 키 invalidate 처리
  - (storage에 아직 반영이 안되는 현상이 있더라구요!)

- 메인 페이지의 API Query에 실시간성을 위해 refetchInterval 60초 부여

## 👩‍💻 공유 포인트 및 논의 사항
