### PR TITLE
🚑 fix: 보관함 페이지 tag 관련 오류 수정

### DIFF
--- a/src/mocks/datas/storage.ts
+++ b/src/mocks/datas/storage.ts
@@ -4,24 +4,20 @@ export const PagedReceivedLettersResponsePage1 = {
   hasNextPage: true,
   letters: [
     {
-      createdAt: '2024-02-21T00:53:25',
-      repliedAt: '2024-02-23T07:51:08',
-      letterId: 1,
-      letterTag: {
-        ageRangeStart: 10,
-        ageRangeEnd: 30,
-        equalGender: true,
-      },
-      senderNickname: '낯선 강아지',
-      receiverNickname: '낯선 유저1',
+      createdAt: '2024-02-23T23:45:54',
+      repliedAt: null,
+      letterId: 11,
+      letterType: 'Onboarding',
+      letterTag: null,
+      senderNickname: '낯선 바다',
+      receiverNickname: null,
       content:
-        '이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300',
-      repliedContent:
-        '이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300 글자 입니다. 이 편지의 내용은 300',
-      worryType: 'WORK',
-      sendImagePath: null,
-      replyImagePath:
-        'https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_1280.jpg',
+        '안녕, 나는 이곳을 운영하고 있는 낯선 바다라고 해. 찾아와줘서 고마워. 너가 와주길 기다리고 있었어.\n나는 말 못할 고민이 있거나 힘든 일이 있을 때, 바다를 찾아가곤해. 내 모든 감정과 생각들을 온전히 이해 받고 공감 받는 기분이 들더라고.\n혹시 너도 마음 속 고민이 있지만 주변 지인에게 부담을 줄까 봐 쉽게 털어 놓지 못했던 경험이 있지 않니?\n내 마음 속 바다에서는 다른 사람에게 말하지 못하는 너만의 고민과 이야기를 물병에 담에 바다에 띄어 보낼 수 있어. 너와 비슷한 고민을 했을 지도 모르는 낯선이로부터 위로의 답장을 주고 받을 수도 있지.\n너에게 말 못할 고민이 있다면, 물병에 담아 띄어보내봐. 혹시 모르잖아. 너의 이름도, 얼굴도 모르는 낯선이로부터 그 누구에게도 받지 못했던 공감과 위로를 받을지.\n기다리고 있을게, 너의 이야기를 듣고싶어.\nP.S. 최근에 갔었던 동해 바다 사진을 동봉해. 너에게도 위로가 되기를',
+      repliedContent: '온보딩 편지에 대한 답장',
+      worryType: null,
+      sendImagePath:
+        'https://letter-img-bucket.s3.ap-northeast-2.amazonaws.com/letter/oceanImage.jpeg',
+      replyImagePath: null,
     },
     {
       createdAt: '2024-02-21T00:53:25',

--- a/src/pages/LetterStoragePage/utils/tagUtills.ts
+++ b/src/pages/LetterStoragePage/utils/tagUtills.ts
@@ -2,11 +2,21 @@ import { WORRY_DICT } from '@/constants/users';
 import { Reply, SendLetter } from '@/types/letter';
 
 export const getTagList = (item: Reply | SendLetter) => {
-  const tagList = [
-    WORRY_DICT[item.worryType],
-    `${item.letterTag.ageRangeStart}~${item.letterTag.ageRangeEnd}세`,
-    item.letterTag.equalGender ? '동성에게' : '모두에게',
-  ];
+  const tagList = [];
+
+  if (WORRY_DICT[item.worryType]) {
+    tagList.push(WORRY_DICT[item.worryType]);
+  }
+
+  if (item.letterTag?.ageRangeStart && item.letterTag?.ageRangeEnd) {
+    tagList.push(
+      `${item.letterTag?.ageRangeStart}~${item.letterTag?.ageRangeEnd}세`,
+    );
+  }
+
+  if (item.letterTag?.equalGender !== undefined) {
+    tagList.push(item.letterTag.equalGender ? '동성에게' : '모두에게');
+  }
 
   return tagList;
 };

--- a/src/types/letter.ts
+++ b/src/types/letter.ts
@@ -28,10 +28,11 @@ export type Reception = {
 };
 
 export type Reply = {
+  letterType: 'Onboarding' | null;
   createdAt: string;
   repliedAt: string;
   letterId: number;
-  letterTag: LetterTag;
+  letterTag: LetterTag | null;
   senderNickname: string;
   receiverNickname: string;
   content: string;
@@ -51,7 +52,7 @@ export type Storage = {
 export type SendLetter = {
   createdAt: string;
   letterId: number;
-  letterTag: LetterTag;
+  letterTag: LetterTag | null;
   senderNickname: string;
   content: string;
   worryType: Worry;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #203 

## ✅ 작업 사항
- 보관함 페이지 tag 관련 오류 수정

## 👩‍💻 공유 포인트 및 논의 사항
### 문제 상황
온보딩 편지의 letterTag는 null인데, 보관함 페이지에서 해당 객체를 다루는 로직이 있어서 크래쉬가 발생했어요.

![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/2065172d-e1be-4271-a357-fa7fc634e471)
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/0227b778-06e2-45ce-a87f-d3da062ef456)

### 해결책

임시로 타입을 명확하게 체크하는 예외 처리 로직을 작성했어요.
(@easyhyun00 우선 급한대로 올려놓을게요!! 추후에 리팩토링하실 때 확인해주시면 감사해요!!)

![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/cf348b11-fe15-4c07-b6d9-dca7e48b4b50)
