### PR TITLE
🚑 fix: 온보딩 편지에 대한 임시 예외 처리 로직 작성

### DIFF
--- a/src/pages/LetterStoragePage/components/StorageLetter.tsx
+++ b/src/pages/LetterStoragePage/components/StorageLetter.tsx
@@ -57,53 +57,72 @@ const StorageLetter = ({ letters }: StorageLetterProps) => {
 
   return (
     <StorageContent>
-      {letters
-        .filter((item) => item.letterType !== 'Onboarding')
-        .map((item) => (
-          <LetterCard key={item.letterId} isOpen={isOpen[item.letterId]}>
-            <div css={style.tags}>
+      {letters.map((item) => (
+        <LetterCard key={item.letterId} isOpen={isOpen[item.letterId]}>
+          <div css={style.tags}>
+            {item.letterType !== 'Onboarding' && (
               <TagList tags={getTagList(item)} />
-              <Dropdown
-                triggerComponent={<MoreHorizontal />}
-                options={[
-                  {
-                    icon: <Copy width={20} height={20} />,
-                    label: '복사하기',
-                    onClick: () => {
-                      handleContentCopy(item.repliedContent);
-                    },
-                    color: COLORS.gray2,
-                  },
-                  {
-                    icon: <TrashCan width={20} height={20} />,
-                    label: '편지 버리기',
-                    onClick: () => {
-                      openBottomSheet(item.letterId);
-                    },
-                    color: COLORS.danger,
-                  },
-                ]}
-              />
-            </div>
-            <LetterHeader nickname={item.senderNickname} />
-            <LetterAccordion
-              id={item.letterId.toString()}
-              text={item.repliedContent}
-              date={new Date(item.createdAt)}
-              nickname={item.receiverNickname}
-              isOpen={isOpen[item.letterId]}
-              onToggle={() => handleAccordionToggle(item.letterId.toString())}
-              line={2}
-            />
-            {isOpen[item.letterId] && item.replyImagePath && (
-              <PolaroidModal
-                topPosition={2.5}
-                leftPosition={1}
-                img={item.replyImagePath}
-              />
             )}
-          </LetterCard>
-        ))}
+            <Dropdown
+              triggerComponent={<MoreHorizontal />}
+              options={[
+                {
+                  icon: <Copy width={20} height={20} />,
+                  label: '복사하기',
+                  onClick: () => {
+                    // TODO: 온보딩 편지는 임시로 content를 보여주도록 했습니다. 추후 수정 필요
+                    handleContentCopy(
+                      item.letterType !== 'Onboarding'
+                        ? item.repliedContent
+                        : item.content,
+                    );
+                  },
+                  color: COLORS.gray2,
+                },
+                {
+                  icon: <TrashCan width={20} height={20} />,
+                  label: '편지 버리기',
+                  onClick: () => {
+                    openBottomSheet(item.letterId);
+                  },
+                  color: COLORS.danger,
+                },
+              ]}
+            />
+          </div>
+          <LetterHeader
+            nickname={
+              item.letterType !== 'Onboarding'
+                ? item.senderNickname
+                : '처음 방문한 너에게'
+            }
+          />
+          <LetterAccordion
+            id={item.letterId.toString()}
+            text={
+              item.letterType !== 'Onboarding'
+                ? item.repliedContent
+                : item.content
+            }
+            date={new Date(item.createdAt)}
+            nickname={
+              item.letterType !== 'Onboarding'
+                ? item.receiverNickname
+                : item.senderNickname
+            }
+            isOpen={isOpen[item.letterId]}
+            onToggle={() => handleAccordionToggle(item.letterId.toString())}
+            line={2}
+          />
+          {isOpen[item.letterId] && item.replyImagePath && (
+            <PolaroidModal
+              topPosition={2.5}
+              leftPosition={1}
+              img={item.replyImagePath}
+            />
+          )}
+        </LetterCard>
+      ))}
       <DeleteBottomSheet value={value} on={on} off={off} letterId={deleteId!} />
     </StorageContent>
   );


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #205

## ✅ 작업 사항
내가 쓴 편지에 대한 답장을 저장할 수 있는 기능이 존재하는데요,
온보딩 편지와 같은 경우에는 내가 쓴 답장을 보여주는 것이 아니라, 편지의 내용을 보여줘야 하는 상황이 발생했어요.

이 부분은 추후에 Letter 엔티티를 일반 편지와 답장으로 구분하는 등의 방법으로 해결할 필요성이 보이는데.. 우선 임시 방편의 코드로 온보딩 편지에 대해서는 편지의 내용을 보여주도록 수정했어요.

## 👩‍💻 공유 포인트 및 논의 사항
