### PR TITLE
🔨 refactor: 내게 온 답장 페이지 테스트 코드 작성

### DIFF
--- a/src/pages/LetterReplyPage/components/BottomButton.test.tsx
+++ b/src/pages/LetterReplyPage/components/BottomButton.test.tsx
@@ -37,8 +37,6 @@ describe('인터랙션 테스트', () => {
     const cancelButton = screen.getByRole('button', { name: '닫기' });
     await user.click(cancelButton);
 
-    console.log(navigateFn);
-
     expect(navigateFn).toHaveBeenCalledWith(ROUTER_PATHS.ROOT);
   });
 });

--- a/src/pages/LetterReplyPage/components/BottomButton.test.tsx
+++ b/src/pages/LetterReplyPage/components/BottomButton.test.tsx
@@ -2,11 +2,24 @@ import { render, screen } from '@/utils/testing-library';
 import { ROUTER_PATHS } from '@/constants/routerPaths';
 import BottomButton from './BottomButton';
 
-global.ResizeObserver = class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
+const ResizeObserver = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.stubGlobal('ResizeObserver', ResizeObserver);
+
+const navigateFn = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const original = await vi.importActual('react-router-dom');
+  return {
+    ...original,
+    useNavigate: () => navigateFn,
+  };
+});
+
 describe('인터랙션 테스트', () => {
   const letter_id = 1;
   it('보관하기 버튼을 누르면 바텀시트가 열린다.', async () => {
@@ -24,6 +37,8 @@ describe('인터랙션 테스트', () => {
     const cancelButton = screen.getByRole('button', { name: '닫기' });
     await user.click(cancelButton);
 
-    expect(window.location.pathname).toEqual(ROUTER_PATHS.ROOT);
+    console.log(navigateFn);
+
+    expect(navigateFn).toHaveBeenCalledWith(ROUTER_PATHS.ROOT);
   });
 });

--- a/src/pages/LetterReplyPage/components/BottomButton.test.tsx
+++ b/src/pages/LetterReplyPage/components/BottomButton.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@/utils/testing-library';
+import { ROUTER_PATHS } from '@/constants/routerPaths';
+import BottomButton from './BottomButton';
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+describe('인터랙션 테스트', () => {
+  const letter_id = 1;
+  it('보관하기 버튼을 누르면 바텀시트가 열린다.', async () => {
+    const { user } = render(<BottomButton letterId={letter_id} />);
+
+    const storageButton = screen.getByRole('button', { name: '보관하기' });
+    await user.click(storageButton);
+
+    const bottomSheet = screen.getByText('편지를 보관함에 저장할까요?');
+    expect(bottomSheet).toBeVisible();
+  });
+  it('닫기 버튼을 누르면 루트 페이지로 간다.', async () => {
+    const { user } = render(<BottomButton letterId={letter_id} />);
+
+    const cancelButton = screen.getByRole('button', { name: '닫기' });
+    await user.click(cancelButton);
+
+    expect(window.location.pathname).toEqual(ROUTER_PATHS.ROOT);
+  });
+});

--- a/src/pages/LetterReplyPage/components/BottomButton.tsx
+++ b/src/pages/LetterReplyPage/components/BottomButton.tsx
@@ -1,53 +1,19 @@
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'react-toastify';
 import { css } from '@emotion/react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import Navbar from '@/components/Navbar';
 import Button from '@/components/Button';
 import { ROUTER_PATHS } from '@/constants/routerPaths';
-import letterAPI from '@/api/letter/apis';
-import letterOptions from '@/api/letter/queryOptions';
-import LoadingSpinner from '@/components/LoadingSpinner';
 import Tooltip from '@/components/Tooltip';
-import ERROR_RESPONSES from '@/constants/errorMessages';
-import BottomSheet from '@/components/BottomSheet';
 import useBoolean from '@/hooks/useBoolean';
+import StorageBottomSheet from './StorageBottomSheet';
 
 interface BottomButtonProps {
   letterId: number;
 }
 
 const BottomButton = ({ letterId }: BottomButtonProps) => {
-  const { value, on, off } = useBoolean(false);
+  const storageBottomSheetProps = useBoolean(false);
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-
-  const { mutateAsync: patchStorage, isPending } = useMutation({
-    mutationFn: letterAPI.patchReplyStorage,
-  });
-
-  const handleStorageLetter = async () => {
-    try {
-      await patchStorage(letterId);
-      queryClient.invalidateQueries({ queryKey: letterOptions.all });
-      toast.success('편지를 보관함에 넣었어요', {
-        autoClose: 1500,
-        position: 'bottom-center',
-      });
-      navigate(ROUTER_PATHS.ROOT);
-    } catch (error) {
-      if (
-        isAxiosError(error) &&
-        (error.response?.data === ERROR_RESPONSES.accessDeniedLetter ||
-          error.response?.data === ERROR_RESPONSES.unAnsweredLetterStore)
-      ) {
-        console.error(error.response?.data);
-      } else {
-        throw error;
-      }
-    }
-  };
 
   return (
     <>
@@ -64,38 +30,18 @@ const BottomButton = ({ letterId }: BottomButtonProps) => {
           delay={10000}
           triggerContent={
             <Button
-              disabled={isPending}
               variant="primary"
               size="sm"
-              onClick={on}
+              onClick={storageBottomSheetProps.on}
             >
-              {isPending ? <LoadingSpinner /> : <>보관하기</>}
+              보관하기
             </Button>
           }
         >
           편지를 보관하여 간직해보세요
         </Tooltip>
       </Navbar>
-      <BottomSheet open={value} onOpen={on} onClose={off}>
-        <BottomSheet.Title>편지를 보관함에 저장할까요?</BottomSheet.Title>
-        <BottomSheet.Description>
-          편지를 보관함에 저장해 언제든지 볼 수 있어요.
-        </BottomSheet.Description>
-        <BottomSheet.ButtonSection>
-          <Button variant="cancel" onClick={off}>
-            취소
-          </Button>
-          <Button
-            variant="primary"
-            onClick={() => {
-              off();
-              handleStorageLetter();
-            }}
-          >
-            보관하기
-          </Button>
-        </BottomSheet.ButtonSection>
-      </BottomSheet>
+      <StorageBottomSheet {...storageBottomSheetProps} letterId={letterId} />
     </>
   );
 };

--- a/src/pages/LetterReplyPage/components/StorageBottomSheet.test.tsx
+++ b/src/pages/LetterReplyPage/components/StorageBottomSheet.test.tsx
@@ -25,7 +25,7 @@ describe('인터랙션 테스트', () => {
 
 describe('API 테스트', () => {
   const letter_id = 1;
-  it('[성공] 보관하기 버튼을 클릭하면 API 호출이 발생하고 처리 중에는 버튼이 비활성화 된다. 요청이 성공하면 루트 페이지로 이동하고 성공 토스트가 나타난다.', async () => {
+  it('[성공] 보관하기 버튼을 클릭하면 API 호출이 발생하고, 요청이 성공하면 루트 페이지로 이동하고 성공 토스트가 나타난다.', async () => {
     const { result: bottomSheetProps } = renderHook(() => useBoolean(true));
     const { user } = render(
       <StorageBottomSheet {...bottomSheetProps.current} letterId={letter_id} />,
@@ -34,13 +34,9 @@ describe('API 테스트', () => {
     const storageButton = screen.getByRole('button', { name: '보관하기' });
     await user.click(storageButton);
 
-    expect(storageButton).toBeDisabled();
-
     await waitFor(() => {
-      expect(storageButton).not.toBeDisabled();
-      expect(bottomSheetProps.current.value).toBe(false);
-      expect(toast.success).toHaveBeenCalledTimes(1);
       expect(window.location.pathname).toEqual(ROUTER_PATHS.ROOT);
+      expect(toast.success).toHaveBeenCalledTimes(1);
     });
   });
   it('[실패] 요청이 실패하면 바텀시트가 닫히고 실패 토스트가 나타난다.', async () => {
@@ -59,10 +55,7 @@ describe('API 테스트', () => {
     const storageButton = screen.getByRole('button', { name: '보관하기' });
     await user.click(storageButton);
 
-    expect(storageButton).toBeDisabled();
-
     await waitFor(() => {
-      expect(storageButton).not.toBeDisabled();
       expect(bottomSheetProps.current.value).toBe(false);
       expect(toast.error).toHaveBeenCalledTimes(1);
     });

--- a/src/pages/LetterReplyPage/components/StorageBottomSheet.test.tsx
+++ b/src/pages/LetterReplyPage/components/StorageBottomSheet.test.tsx
@@ -1,0 +1,70 @@
+import { toast } from 'react-toastify';
+import { http } from 'msw';
+import { render, screen, renderHook, waitFor } from '@/utils/testing-library';
+import useBoolean from '@/hooks/useBoolean';
+import { ROUTER_PATHS, API_PATHS } from '@/constants/routerPaths';
+import { server } from '@/mocks/node';
+import { baseURL } from '@/utils/mswUtils';
+import { letterResolvers } from '@/mocks/resolvers/letter';
+import StorageBottomSheet from './StorageBottomSheet';
+
+describe('인터랙션 테스트', () => {
+  const letter_id = 1;
+  it('취소 버튼을 누르면 바텀시트가 닫힌다.', async () => {
+    const { result: bottomSheetProps } = renderHook(() => useBoolean(true));
+    const { user } = render(
+      <StorageBottomSheet {...bottomSheetProps.current} letterId={letter_id} />,
+    );
+
+    const cancelButton = screen.getByRole('button', { name: '취소' });
+    await user.click(cancelButton);
+
+    expect(bottomSheetProps.current.value).toBe(false);
+  });
+});
+
+describe('API 테스트', () => {
+  const letter_id = 1;
+  it('[성공] 보관하기 버튼을 클릭하면 API 호출이 발생하고 처리 중에는 버튼이 비활성화 된다. 요청이 성공하면 루트 페이지로 이동하고 성공 토스트가 나타난다.', async () => {
+    const { result: bottomSheetProps } = renderHook(() => useBoolean(true));
+    const { user } = render(
+      <StorageBottomSheet {...bottomSheetProps.current} letterId={letter_id} />,
+    );
+
+    const storageButton = screen.getByRole('button', { name: '보관하기' });
+    await user.click(storageButton);
+
+    expect(storageButton).toBeDisabled();
+
+    await waitFor(() => {
+      expect(storageButton).not.toBeDisabled();
+      expect(bottomSheetProps.current.value).toBe(false);
+      expect(toast.success).toHaveBeenCalledTimes(1);
+      expect(window.location.pathname).toEqual(ROUTER_PATHS.ROOT);
+    });
+  });
+  it('[실패] 요청이 실패하면 바텀시트가 닫히고 실패 토스트가 나타난다.', async () => {
+    server.use(
+      http.patch(
+        baseURL(API_PATHS.LETTER_REPLY_STORAGE_DETAIL(letter_id.toString())),
+        letterResolvers.patchLetterReplyStorageDetail.unAnsweredLetterStore,
+      ),
+    );
+
+    const { result: bottomSheetProps } = renderHook(() => useBoolean(true));
+    const { user } = render(
+      <StorageBottomSheet {...bottomSheetProps.current} letterId={letter_id} />,
+    );
+
+    const storageButton = screen.getByRole('button', { name: '보관하기' });
+    await user.click(storageButton);
+
+    expect(storageButton).toBeDisabled();
+
+    await waitFor(() => {
+      expect(storageButton).not.toBeDisabled();
+      expect(bottomSheetProps.current.value).toBe(false);
+      expect(toast.error).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/pages/LetterReplyPage/components/StorageBottomSheet.tsx
+++ b/src/pages/LetterReplyPage/components/StorageBottomSheet.tsx
@@ -1,0 +1,78 @@
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import Button from '@/components/Button';
+import { ROUTER_PATHS } from '@/constants/routerPaths';
+import letterAPI from '@/api/letter/apis';
+import letterOptions from '@/api/letter/queryOptions';
+import ERROR_RESPONSES from '@/constants/errorMessages';
+import BottomSheet from '@/components/BottomSheet';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import useBoolean from '@/hooks/useBoolean';
+
+interface StorageBottomSheetProps extends ReturnType<typeof useBoolean> {
+  letterId: number;
+}
+
+const StorageBottomSheet = ({
+  value,
+  on,
+  off,
+  letterId,
+}: StorageBottomSheetProps) => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { mutateAsync: patchStorage, isPending } = useMutation({
+    mutationFn: letterAPI.patchReplyStorage,
+  });
+
+  const handleStorageLetter = async () => {
+    try {
+      await patchStorage(letterId);
+      queryClient.invalidateQueries({ queryKey: letterOptions.all });
+      toast.success('편지를 보관함에 넣었어요', {
+        autoClose: 1500,
+        position: 'bottom-center',
+      });
+      navigate(ROUTER_PATHS.ROOT);
+    } catch (error) {
+      if (
+        isAxiosError(error) &&
+        (error.response?.data === ERROR_RESPONSES.accessDeniedLetter ||
+          error.response?.data === ERROR_RESPONSES.unAnsweredLetterStore)
+      ) {
+        console.error(error.response?.data);
+      } else {
+        throw error;
+      }
+    }
+    off();
+  };
+
+  return (
+    <BottomSheet open={value} onOpen={on} onClose={off}>
+      <BottomSheet.Title>편지를 보관함에 저장할까요?</BottomSheet.Title>
+      <BottomSheet.Description>
+        편지를 보관함에 저장해 언제든지 볼 수 있어요.
+      </BottomSheet.Description>
+      <BottomSheet.ButtonSection>
+        <Button variant="cancel" onClick={off}>
+          취소
+        </Button>
+        <Button
+          disabled={isPending}
+          variant="primary"
+          onClick={() => {
+            handleStorageLetter();
+          }}
+        >
+          {isPending ? <LoadingSpinner /> : <>보관하기</>}
+        </Button>
+      </BottomSheet.ButtonSection>
+    </BottomSheet>
+  );
+};
+
+export default StorageBottomSheet;

--- a/src/pages/LetterReplyPage/hooks/useLetterReplyWithTag.ts
+++ b/src/pages/LetterReplyPage/hooks/useLetterReplyWithTag.ts
@@ -12,9 +12,6 @@ const useLetterReplyWithTag = (letterId: number) => {
     ...letterOptions.singleReply(letterId),
   });
 
-  /**
-   * TODO: 나이, 성별 태그값 배열에 넣기
-   */
   const tagList = data
     ? [
         WORRY_DICT[data.worryType],

--- a/src/pages/LetterReplyPage/replyLetter/index.test.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.test.tsx
@@ -3,7 +3,7 @@ import { server } from '@/mocks/node';
 import { baseURL } from '@/utils/mswUtils';
 import { API_PATHS } from '@/constants/routerPaths';
 import { ReplyLetter as ReplyLetterData } from '@/mocks/datas/letter';
-import { render, screen, waitFor } from '@/utils/testing-library';
+import { render, screen } from '@/utils/testing-library';
 import { formatDate } from '@/utils/dateUtils';
 import ReplyLetter from '.';
 
@@ -56,14 +56,7 @@ describe('인터랙션 테스트', () => {
 
     const { user } = render(<ReplyLetter letterId={letter_id} />);
 
-    await waitFor(() => {
-      screen.getByAltText('편지와 함께 보낸 이미지');
-    });
-
-    const imageElement = (await screen.getByAltText(
-      '편지와 함께 보낸 이미지',
-    )) as HTMLImageElement;
-
+    const imageElement = await screen.findByAltText('편지와 함께 보낸 이미지');
     await user.click(imageElement);
 
     const imageDownButton = document.querySelector('#download-button');

--- a/src/pages/LetterReplyPage/replyLetter/index.test.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.test.tsx
@@ -1,0 +1,44 @@
+import { HttpResponse, http } from 'msw';
+import { server } from '@/mocks/node';
+import { baseURL } from '@/utils/mswUtils';
+import { API_PATHS } from '@/constants/routerPaths';
+import { ReplyLetter as ReplyLetterData } from '@/mocks/datas/letter';
+import { render, screen } from '@/utils/testing-library';
+import { formatDate } from '@/utils/dateUtils';
+import ReplyLetter from '.';
+
+describe('렌더링 테스트', () => {
+  it('답장 받은 편지가 렌더링 된다.', async () => {
+    const letter_id = 1;
+    server.use(
+      http.get(
+        baseURL(API_PATHS.LETTER_REPLY_DETAIL(letter_id.toString())),
+        () => HttpResponse.json(ReplyLetterData(letter_id)),
+      ),
+    );
+    render(<ReplyLetter letterId={letter_id} />);
+
+    const receiverNickname = await screen.findByText(
+      ReplyLetterData(letter_id).receiverNickname,
+    );
+    const repliedContent = await screen.findByText(
+      ReplyLetterData(letter_id).repliedContent,
+    );
+    const repliedAt = await screen.findByText(
+      formatDate(new Date(ReplyLetterData(letter_id).repliedAt)),
+    );
+    const senderNickname = await screen.findByText(
+      ReplyLetterData(letter_id).senderNickname,
+    );
+    const imageElement = (await screen.getByAltText(
+      '편지와 함께 보낸 이미지',
+    )) as HTMLImageElement;
+    const replyImagePath = ReplyLetterData(letter_id).replyImagePath;
+
+    expect(receiverNickname).toBeInTheDocument();
+    expect(repliedContent).toBeInTheDocument();
+    expect(repliedAt).toBeInTheDocument();
+    expect(senderNickname).toBeInTheDocument();
+    expect(imageElement.src).toContain(replyImagePath);
+  });
+});

--- a/src/pages/LetterReplyPage/replyLetter/index.test.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.test.tsx
@@ -3,7 +3,7 @@ import { server } from '@/mocks/node';
 import { baseURL } from '@/utils/mswUtils';
 import { API_PATHS } from '@/constants/routerPaths';
 import { ReplyLetter as ReplyLetterData } from '@/mocks/datas/letter';
-import { render, screen } from '@/utils/testing-library';
+import { render, screen, waitFor } from '@/utils/testing-library';
 import { formatDate } from '@/utils/dateUtils';
 import ReplyLetter from '.';
 
@@ -40,5 +40,34 @@ describe('렌더링 테스트', () => {
     expect(repliedAt).toBeInTheDocument();
     expect(senderNickname).toBeInTheDocument();
     expect(imageElement.src).toContain(replyImagePath);
+  });
+});
+
+describe('인터랙션 테스트', () => {
+  it('폴라로이드 사진을 클릭하면 모달이 열린다.', async () => {
+    const letter_id = 1;
+
+    server.use(
+      http.get(
+        baseURL(API_PATHS.LETTER_REPLY_DETAIL(letter_id.toString())),
+        () => HttpResponse.json(ReplyLetterData(letter_id)),
+      ),
+    );
+
+    const { user } = render(<ReplyLetter letterId={letter_id} />);
+
+    await waitFor(() => {
+      screen.getByAltText('편지와 함께 보낸 이미지');
+    });
+
+    const imageElement = (await screen.getByAltText(
+      '편지와 함께 보낸 이미지',
+    )) as HTMLImageElement;
+
+    await user.click(imageElement);
+
+    const imageDownButton = document.querySelector('#download-button');
+
+    expect(imageDownButton).toBeInTheDocument();
   });
 });

--- a/src/pages/LetterReplyPage/replyLetter/index.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.tsx
@@ -6,8 +6,8 @@ import PolaroidModal from '@/components/PolaroidModal';
 import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
 import { Download } from '@/assets/icons';
-import LetterContent from '../components/LetterContent';
 import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
+import LetterContent from '../components/LetterContent';
 
 interface ReplyLetterProps {
   letterId: number;
@@ -51,7 +51,7 @@ const ReplyLetter = ({ letterId }: ReplyLetterProps) => {
           leftPosition={1.2}
           img={replyLetter.replyImagePath}
           headerRightContent={
-            <IconButton onClick={handleDownload}>
+            <IconButton id="download-button" onClick={handleDownload}>
               <Download color="white" height={20} width={20} />
             </IconButton>
           }

--- a/src/pages/LetterReplyPage/sentLetter/index.test.tsx
+++ b/src/pages/LetterReplyPage/sentLetter/index.test.tsx
@@ -44,7 +44,7 @@ describe('렌더링 테스트', () => {
     const receiverNickname = await screen.findByText(
       ReplyLetterData(letter_id).receiverNickname,
     );
-    const imageElement = (await screen.getByAltText(
+    const imageElement = (await screen.findByAltText(
       '편지와 함께 보낸 이미지',
     )) as HTMLImageElement;
     const sendImagePath = ReplyLetterData(letter_id).sendImagePath;

--- a/src/pages/LetterReplyPage/sentLetter/index.test.tsx
+++ b/src/pages/LetterReplyPage/sentLetter/index.test.tsx
@@ -1,0 +1,61 @@
+import { HttpResponse, http } from 'msw';
+import { server } from '@/mocks/node';
+import { baseURL } from '@/utils/mswUtils';
+import { API_PATHS } from '@/constants/routerPaths';
+import { ReplyLetter as ReplyLetterData } from '@/mocks/datas/letter';
+import { render, screen } from '@/utils/testing-library';
+import { formatDate } from '@/utils/dateUtils';
+import { WORRY_DICT } from '@/constants/users';
+import SentLetter from '.';
+
+describe('렌더링 테스트', () => {
+  it('모달이 열리고 내가 보낸 편지가 렌더링 된다.', async () => {
+    const letter_id = 1;
+    server.use(
+      http.get(
+        baseURL(API_PATHS.LETTER_REPLY_DETAIL(letter_id.toString())),
+        () => HttpResponse.json(ReplyLetterData(letter_id)),
+      ),
+    );
+    const { user } = render(<SentLetter letterId={letter_id} />);
+
+    const sentContainer = await screen.findByText('내가 보낸 편지');
+
+    await user.click(sentContainer);
+
+    const worry = await screen.findByText(
+      WORRY_DICT[ReplyLetterData(letter_id).worryType],
+    );
+    const age = await screen.findByText(
+      `${ReplyLetterData(letter_id).letterTag?.ageRangeStart}~${ReplyLetterData(letter_id).letterTag?.ageRangeEnd}세`,
+    );
+    const gender = await screen.findByText(
+      ReplyLetterData(letter_id).letterTag?.equalGender
+        ? '동성에게'
+        : '모두에게',
+    );
+    const senderNickname = await screen.findByText(
+      ReplyLetterData(letter_id).senderNickname,
+    );
+    const content = await screen.findByText(ReplyLetterData(letter_id).content);
+    const createdAt = await screen.findByText(
+      formatDate(new Date(ReplyLetterData(letter_id).createdAt)),
+    );
+    const receiverNickname = await screen.findByText(
+      ReplyLetterData(letter_id).receiverNickname,
+    );
+    const imageElement = (await screen.getByAltText(
+      '편지와 함께 보낸 이미지',
+    )) as HTMLImageElement;
+    const sendImagePath = ReplyLetterData(letter_id).sendImagePath;
+
+    expect(worry).toBeInTheDocument();
+    expect(age).toBeInTheDocument();
+    expect(gender).toBeInTheDocument();
+    expect(senderNickname).toBeInTheDocument();
+    expect(content).toBeInTheDocument();
+    expect(createdAt).toBeInTheDocument();
+    expect(receiverNickname).toBeInTheDocument();
+    expect(imageElement.src).toContain(sendImagePath);
+  });
+});

--- a/src/pages/LetterReplyPage/sentLetter/index.test.tsx
+++ b/src/pages/LetterReplyPage/sentLetter/index.test.tsx
@@ -59,3 +59,32 @@ describe('렌더링 테스트', () => {
     expect(imageElement.src).toContain(sendImagePath);
   });
 });
+
+describe('인터랙션 테스트', () => {
+  it('폴라로이드 사진을 클릭하면 모달이 열린다.', async () => {
+    const letter_id = 1;
+
+    server.use(
+      http.get(
+        baseURL(API_PATHS.LETTER_REPLY_DETAIL(letter_id.toString())),
+        () => HttpResponse.json(ReplyLetterData(letter_id)),
+      ),
+    );
+
+    const { user } = render(<SentLetter letterId={letter_id} />);
+
+    const sentContainer = await screen.findByText('내가 보낸 편지');
+
+    await user.click(sentContainer);
+
+    const imageElement = (await screen.getByAltText(
+      '편지와 함께 보낸 이미지',
+    )) as HTMLImageElement;
+
+    await user.click(imageElement);
+
+    const modalCloseButton = screen.getByRole('button', { name: '닫기' });
+
+    expect(modalCloseButton).toBeInTheDocument();
+  });
+});

--- a/src/pages/LetterReplyPage/sentLetter/index.tsx
+++ b/src/pages/LetterReplyPage/sentLetter/index.tsx
@@ -8,8 +8,8 @@ import PolaroidModal from '@/components/PolaroidModal';
 import TagList from '@/components/TagList';
 import Button from '@/components/Button';
 import { formatDate } from '@/utils/dateUtils';
-import LetterContent from '../components/LetterContent';
 import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
+import LetterContent from '../components/LetterContent';
 import style from './styles';
 interface SentLetterProps {
   letterId: number;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #230 

## ✅ 작업 사항

내게 온 답장 페이지 테스트 코드를 작성하고 mutate 으로 수정하였습니다.

### 답장 온 편지 렌더링 테스트

답장 온 편지 컴포넌트의 닉네임, 내용, 날짜, 이미지 렌더링 테스트를 하였습니다.

### 내가 보낸 편지 렌더링 테스트

`내가 보낸 편지` 컴포넌트를 클릭하여 내가 보낸 편지의 닉네임, 내용,날짜, 이미지가 렌더링 되었는지 테스트하였습니다.

### 하단 버튼 인터랙션 테스트

보관하기 버튼을 누르면 바텀시트가 열리는 지 테스트 하였고
보관하기 옆에 닫기 버튼을 누르면 루트 페이지로 가는지 테스트 하였습니다.

### 보관하기 바텀시트 API 테스트

성공하면 루트 페이지로 이동하고 성공 토스트가 나타나는 지 테스트 하였고
실패하면 바텀시트가 닫히고 실패 토스트가 나타나는 지 테스트 하였습니다.

### 테스트 결과
<img width="517" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/e29bbdb1-8b2e-4726-a8b5-a7ce421e1da5">

### mutate 수정

mutateAsync 에서 mutate 로 수정하였습니다.

```tsx
    mutate(letterId, {
      onSuccess: () => {
        toast.success('편지를 보관함에 넣었어요', {
          autoClose: 1500,
          position: 'bottom-center',
        });
        navigate(ROUTER_PATHS.ROOT);
      },
    });
    off();
```

## 👩‍💻 공유 포인트 및 논의 사항

이미지 모달에서 상단에 있는 다운로드 버튼을 클릭하면 이미지가 제대로 다운로드 되는지 테스트하고 싶었는데
axios 를 사용해서 다운로드 하는 거라 네트워크 오류가 발생하고 해결하고 싶었는데 잘 안되어서 테스트 코드는 작성하지 못했습니다..
