### PR TITLE
🔨 refactor: Tabs 합성 컴포넌트로 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "clsx": "^2.1.0",
         "embla-carousel-react": "^8.0.0-rc22",
         "framer-motion": "^10.18.0",
+        "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.12",
@@ -13628,6 +13629,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clsx": "^2.1.0",
     "embla-carousel-react": "^8.0.0-rc22",
     "framer-motion": "^10.18.0",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.12",

--- a/src/AdminApp.tsx
+++ b/src/AdminApp.tsx
@@ -1,0 +1,31 @@
+import { Outlet } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
+import { css } from '@emotion/react';
+import Background from '@/components/Background';
+import BackgroundImg from '@/assets/background.png';
+import UnknownErrorBoundary from '@/components/ErrorBoundary/UnknownErrorBoundary';
+import ApiErrorBoundary from '@/components/ErrorBoundary/ApiErrorBoundary';
+import RootApiFallback from './components/ErrorBoundary/fallback/RootApiFallback';
+import RootUnknownFallback from './components/ErrorBoundary/fallback/RootUnknownFallback';
+import 'react-toastify/dist/ReactToastify.css';
+
+const AdminApp = () => {
+  return (
+    <Background imageUrl={BackgroundImg}>
+      <UnknownErrorBoundary FallbackComponent={RootUnknownFallback}>
+        <ApiErrorBoundary FallbackComponent={RootApiFallback}>
+          <Outlet />
+        </ApiErrorBoundary>
+      </UnknownErrorBoundary>
+      <ToastContainer
+        css={css({
+          margin: '4rem 0 5rem 0',
+          padding: '0 1rem',
+          boxSizing: 'border-box',
+        })}
+      />
+    </Background>
+  );
+};
+
+export default AdminApp;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,21 +14,34 @@ import 'react-toastify/dist/ReactToastify.css';
 const App = () => {
   return (
     <Background imageUrl={BackgroundImg}>
-      <UnknownErrorBoundary FallbackComponent={RootUnknownFallback}>
-        <ApiErrorBoundary FallbackComponent={RootApiFallback}>
-          <Outlet />
-        </ApiErrorBoundary>
-      </UnknownErrorBoundary>
-      <Audio src={BackgroundMusic} />
-      <ToastContainer
-        css={css({
-          margin: '4rem 0 5rem 0',
-          padding: '0 1rem',
-          boxSizing: 'border-box',
-        })}
-      />
+      <div css={styles.root}>
+        <UnknownErrorBoundary FallbackComponent={RootUnknownFallback}>
+          <ApiErrorBoundary FallbackComponent={RootApiFallback}>
+            <Outlet />
+          </ApiErrorBoundary>
+        </UnknownErrorBoundary>
+        <Audio src={BackgroundMusic} />
+        <ToastContainer
+          css={css({
+            margin: '4rem 0 5rem 0',
+            padding: '0 1rem',
+            boxSizing: 'border-box',
+          })}
+        />
+      </div>
     </Background>
   );
+};
+
+const styles = {
+  root: css`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 600px;
+    margin: 0 auto;
+  `,
 };
 
 export default App;

--- a/src/api/admin/apis.ts
+++ b/src/api/admin/apis.ts
@@ -1,0 +1,68 @@
+import { API_PATHS } from '@/constants/routerPaths';
+import {
+  type PagedMemberResponse,
+  type PagedReportResponse,
+} from '@/types/admin';
+import { authInstance } from '../instance';
+
+const adminAPI = {
+  getReport: async (params?: { page?: string; email?: string }) => {
+    const { data } = await authInstance.get<PagedReportResponse>(
+      API_PATHS.ADMIN_REPORT,
+      {
+        params,
+      },
+    );
+    return data;
+  },
+
+  getMemberSearch: async (params?: { page?: string; email?: string }) => {
+    const { data } = await authInstance.get<PagedMemberResponse>(
+      API_PATHS.ADMIN_MEMBER_SEARCH,
+      {
+        params,
+      },
+    );
+    return data;
+  },
+
+  deleteMember: async (email: string) => {
+    const { data } = await authInstance.delete(API_PATHS.ADMIN_MEMBER_SEARCH, {
+      params: {
+        email,
+      },
+    });
+    return data;
+  },
+
+  postSpecialLetter: async ({
+    content,
+    email,
+    image,
+  }: {
+    email: string;
+    content: string;
+    image?: File;
+  }) => {
+    const formData = new FormData();
+    formData.append('content', content);
+    formData.append('email', email);
+
+    if (image) {
+      formData.append('image', image);
+    }
+
+    const { data } = await authInstance.post(
+      API_PATHS.ADMIN_LETTER_SPECIAL,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    );
+    return data;
+  },
+};
+
+export default adminAPI;

--- a/src/api/admin/queryOptions.ts
+++ b/src/api/admin/queryOptions.ts
@@ -1,0 +1,20 @@
+import { queryOptions } from '@tanstack/react-query';
+import adminAPI from './apis';
+
+const adminOptions = {
+  all: ['admin'] as const,
+
+  member: (params?: { page?: string; email?: string }) =>
+    queryOptions({
+      queryKey: [...adminOptions.all, 'member', params] as const,
+      queryFn: () => adminAPI.getMemberSearch(params),
+    }),
+
+  report: (params?: { page?: string; reportedEmail?: string }) =>
+    queryOptions({
+      queryKey: [...adminOptions.all, 'report', params] as const,
+      queryFn: () => adminAPI.getReport(params),
+    }),
+};
+
+export default adminOptions;

--- a/src/components/Background/index.tsx
+++ b/src/components/Background/index.tsx
@@ -7,11 +7,7 @@ interface BackgroundProps extends React.ComponentPropsWithoutRef<'div'> {
 }
 
 const Background = ({ imageUrl, children }: BackgroundProps) => {
-  return (
-    <div css={styles.background(imageUrl)}>
-      <div css={styles.wrapper}>{children}</div>
-    </div>
-  );
+  return <div css={styles.background(imageUrl)}>{children}</div>;
 };
 
 export default Background;

--- a/src/components/Background/styles.ts
+++ b/src/components/Background/styles.ts
@@ -63,15 +63,6 @@ const style = {
       animation-duration: 40000s;
     }
   `,
-
-  wrapper: css`
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
-    max-width: 600px;
-    margin: 0 auto;
-  `,
 };
 
 export default style;

--- a/src/components/PaginationBar/index.tsx
+++ b/src/components/PaginationBar/index.tsx
@@ -4,6 +4,8 @@ import IconButton from '../IconButton';
 import styles from './style';
 
 interface PaginationBarProps {
+  /** 현재 페이지 번호 */
+  page?: number;
   /** 기본 페이지 번호 */
   defaultPage: number;
   /** 페이지 갯수 */
@@ -13,6 +15,7 @@ interface PaginationBarProps {
 }
 
 const PaginationBar = ({
+  page,
   defaultPage,
   count,
   onChange = () => {},
@@ -20,6 +23,7 @@ const PaginationBar = ({
   const { items } = usePagination({
     siblingCount: 0,
     boundaryCount: 1,
+    page,
     defaultPage,
     count,
     onChange: (_, page) => onChange(page),

--- a/src/components/Tabs/components/Content.tsx
+++ b/src/components/Tabs/components/Content.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import * as T from '@radix-ui/react-tabs';
+
+interface ContentProps {
+  /** 탭의 value 값 */
+  value: string;
+  /** 안에 들어갈 컨텐츠 */
+  children?: React.ReactNode;
+}
+
+const Content = ({ value, children, ...props }: ContentProps) => {
+  return (
+    <T.Content value={value} {...props}>
+      {children}
+    </T.Content>
+  );
+};
+
+export default Content;

--- a/src/components/Tabs/components/List.tsx
+++ b/src/components/Tabs/components/List.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import * as T from '@radix-ui/react-tabs';
+import styles from '../styles';
+import { useTabsContext } from '../contexts/TabsContext';
+
+interface ListProps {
+  /** 탭 목록에 들어갈 컨텐츠 */
+  children?: React.ReactNode;
+}
+
+const List = ({ children, ...props }: ListProps) => {
+  const { variant } = useTabsContext();
+
+  return (
+    <T.List css={styles.list(variant)} aria-label="Tabs" {...props}>
+      {children}
+    </T.List>
+  );
+};
+
+export default List;

--- a/src/components/Tabs/components/Trigger.tsx
+++ b/src/components/Tabs/components/Trigger.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import * as T from '@radix-ui/react-tabs';
+import styles from '../styles';
+import { useTabsContext } from '../contexts/TabsContext';
+
+interface TriggerProps {
+  /** 탭의 value 값 */
+  value: string;
+  /** 탭 트리거 요소 들어갈 컨텐츠 */
+  children?: React.ReactNode;
+}
+
+const Trigger = ({ value, children, ...props }: TriggerProps) => {
+  const { variant } = useTabsContext();
+
+  return (
+    <T.Trigger css={styles.trigger(variant)} value={value} {...props}>
+      {children}
+    </T.Trigger>
+  );
+};
+
+export default Trigger;

--- a/src/components/Tabs/contexts/TabsContext.ts
+++ b/src/components/Tabs/contexts/TabsContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import { type TabsVariant } from '../styles';
+
+const TabsContext = createContext<{
+  variant: TabsVariant;
+} | null>(null);
+
+export const TabsProvider = TabsContext.Provider;
+
+export const useTabsContext = () => {
+  const context = useContext(TabsContext);
+
+  if (!context) {
+    throw new Error('useTabsContext must be used within a TabsProvider');
+  }
+
+  return context;
+};

--- a/src/components/Tabs/index.stories.tsx
+++ b/src/components/Tabs/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type ComponentType } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { css } from '@emotion/react';
 import Tabs from './';
@@ -6,6 +6,11 @@ import Tabs from './';
 const meta = {
   title: 'Components/Tabs',
   component: Tabs,
+  subcomponents: {
+    List: Tabs.List as ComponentType<unknown>,
+    Trigger: Tabs.Trigger as ComponentType<unknown>,
+    Content: Tabs.Content as ComponentType<unknown>,
+  },
   tags: ['autodocs'],
   argTypes: {},
 } satisfies Meta<typeof Tabs>;
@@ -14,95 +19,68 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
-  render: (args) => (
-    <div
-      css={css`
-        padding: 1.25rem;
-        background-color: #8acef5;
-      `}
-    >
-      <Tabs {...args} />
-    </div>
-  ),
-  args: {
-    defaultValue: 'tab2',
-    variant: 'primary',
-    tabItems: [
-      {
-        key: 'tab1',
-        label: 'One',
-        content: 'Tab one content',
-      },
-      {
-        key: 'tab2',
-        label: 'Two',
-        content: 'Tab two content',
-      },
-      {
-        key: 'tab3',
-        label: 'Three',
-        content: 'Tab three content',
-      },
-    ],
-  },
+const styles = {
+  container: css`
+    padding: 1.25rem;
+    background-color: #8acef5;
+  `,
+  content: css`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 1rem;
+
+    &:empty {
+      display: none;
+    }
+  `,
 };
 
-const 보관함Components = {
-  Content: ({ children }: React.PropsWithChildren) => {
-    return (
-      <div
-        css={css`
-          display: flex;
-          flex-direction: column;
-          gap: 1rem;
-          margin-top: 1rem;
-        `}
-      >
-        {children}
-      </div>
-    );
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    defaultValue: 'tab2',
   },
+  decorators: (Story) => (
+    <div css={styles.container}>
+      <Story />
+    </div>
+  ),
+  render: (args) => (
+    <Tabs {...args}>
+      <Tabs.List>
+        <Tabs.Trigger value="tab1">One</Tabs.Trigger>
+        <Tabs.Trigger value="tab2">Two</Tabs.Trigger>
+        <Tabs.Trigger value="tab3">Three</Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="tab1">Tab one content</Tabs.Content>
+      <Tabs.Content value="tab2">Tab two content</Tabs.Content>
+      <Tabs.Content value="tab3">Tab three content</Tabs.Content>
+    </Tabs>
+  ),
 };
 
 export const 보관함: Story = {
-  render: (args) => (
-    <div
-      css={css`
-        padding: 1.25rem;
-        background-color: #8acef5;
-      `}
-    >
-      <Tabs {...args} />
-    </div>
-  ),
+  ...Primary,
   args: {
-    variant: 'primary',
-    tabItems: [
-      {
-        key: '1',
-        label: '보관한 편지',
-        content: (
-          <보관함Components.Content>
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i}>from. 낯선 고양이.... 보관한 편지 내용... {i}</div>
-            ))}
-          </보관함Components.Content>
-        ),
-      },
-      {
-        key: '2',
-        label: '내가 보낸 편지',
-        content: (
-          <보관함Components.Content>
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i}>
-                from. 낯선 고양이.... 내가 보낸 편지 내용... {i}
-              </div>
-            ))}
-          </보관함Components.Content>
-        ),
-      },
-    ],
+    defaultValue: 'tab1',
   },
+  render: (args) => (
+    <Tabs {...args}>
+      <Tabs.List>
+        <Tabs.Trigger value="tab1">One</Tabs.Trigger>
+        <Tabs.Trigger value="tab2">Two</Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="tab1" css={styles.content}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i}>from. 낯선 고양이.... 보관한 편지 내용... {i}</div>
+        ))}
+      </Tabs.Content>
+      <Tabs.Content value="tab2" css={styles.content}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i}>from. 낯선 고양이.... 보관한 편지 내용... {i}</div>
+        ))}
+      </Tabs.Content>
+    </Tabs>
+  ),
 };

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,45 +1,30 @@
 import React from 'react';
 import * as T from '@radix-ui/react-tabs';
-import styles, { type TabsVariant } from './styles';
+import { type TabsVariant } from './styles';
+import { TabsProvider } from './contexts/TabsContext';
+import List from './components/List';
+import Trigger from './components/Trigger';
+import Content from './components/Content';
 
 interface TabsProps {
   /** 탭의 배경 색상과 스타일 등 테마를 지정합니다. */
   variant?: TabsVariant;
   /** 기본으로 활성화 되어 있을 탭 아이템의 key를 지정합니다.  */
   defaultValue?: string;
-  /** 탭 아이템의 목록을 지정합니다. */
-  tabItems: {
-    key: string;
-    label: React.ReactNode;
-    content: React.ReactNode;
-  }[];
+  /** Tabs 컴포넌트 안에 포함될 내용입니다. */
+  children?: React.ReactNode;
 }
 
-const Tabs = ({ variant = 'primary', defaultValue, tabItems }: TabsProps) => {
-  defaultValue = defaultValue ?? tabItems[0].key;
-
+const Tabs = ({ variant = 'primary', defaultValue, children }: TabsProps) => {
   return (
-    <T.Root defaultValue={defaultValue}>
-      <T.List css={styles.list(variant)} aria-label="Tabs">
-        {tabItems.map((tabItem) => (
-          <T.Trigger
-            css={styles.trigger(variant)}
-            key={tabItem.key}
-            value={tabItem.key}
-          >
-            {tabItem.label}
-          </T.Trigger>
-        ))}
-      </T.List>
-
-      {tabItems.map((tabItem) => (
-        <T.Content key={tabItem.key} value={tabItem.key}>
-          {tabItem.content}
-        </T.Content>
-      ))}
-    </T.Root>
+    <TabsProvider value={{ variant }}>
+      <T.Root defaultValue={defaultValue}>{children}</T.Root>
+    </TabsProvider>
   );
 };
 
+Tabs.List = List;
+Tabs.Trigger = Trigger;
+Tabs.Content = Content;
+
 export default Tabs;
-export { default as tabsStyles } from './styles';

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -11,14 +11,28 @@ interface TabsProps {
   variant?: TabsVariant;
   /** 기본으로 활성화 되어 있을 탭 아이템의 key를 지정합니다.  */
   defaultValue?: string;
+  /** 탭 아이템이 변경될 때 호출되는 콜백 함수입니다. */
+  onValueChange?: (value: string) => void;
   /** Tabs 컴포넌트 안에 포함될 내용입니다. */
   children?: React.ReactNode;
 }
 
-const Tabs = ({ variant = 'primary', defaultValue, children }: TabsProps) => {
+const Tabs = ({
+  variant = 'primary',
+  defaultValue,
+  onValueChange,
+  children,
+  ...props
+}: TabsProps) => {
   return (
     <TabsProvider value={{ variant }}>
-      <T.Root defaultValue={defaultValue}>{children}</T.Root>
+      <T.Root
+        defaultValue={defaultValue}
+        onValueChange={onValueChange}
+        {...props}
+      >
+        {children}
+      </T.Root>
     </TabsProvider>
   );
 };

--- a/src/constants/routerPaths.ts
+++ b/src/constants/routerPaths.ts
@@ -37,6 +37,10 @@ export const API_PATHS = {
     `/api/letter/send/${letterId}` as const,
 
   REPORT_SEND: '/api/report',
+
+  ADMIN_REPORT: '/api/report',
+  ADMIN_MEMBER_SEARCH: '/api/member/search',
+  ADMIN_LETTER_SPECIAL: '/api/letter/special',
 } as const;
 
 export const ROUTER_PATHS = {
@@ -49,4 +53,5 @@ export const ROUTER_PATHS = {
   MYPAGE: '/mypage',
   LETTER_REPLY: (letterId: string) => `/reply/${letterId}` as const,
   LETTER_STORAGE: `/storage`,
+  ADMIN: '/admin',
 } as const;

--- a/src/constants/users.ts
+++ b/src/constants/users.ts
@@ -42,6 +42,7 @@ export const GENDER_DICT = {
 
 export const ROLE_DICT = {
   USER: '사용자',
+  ADMIN: '관리자',
 } as const;
 
 export type Nickname = (typeof NICKNAMES)[number];

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { ROUTER_PATHS } from '@/constants/routerPaths';
+import STORAGE_KEYS from '@/constants/storageKeys';
+import LoadingScreen from '@/components/LoadingScreen';
+import memberOptions from '@/api/member/queryOptions';
+
+const SuspensedLayout = () => {
+  const { data } = useSuspenseQuery(memberOptions.detail());
+
+  if (data.role !== 'ADMIN') {
+    return <Navigate to={ROUTER_PATHS.SIGNIN} />;
+  }
+
+  return <Outlet />;
+};
+
+const AdminLayout = () => {
+  if (!localStorage.getItem(STORAGE_KEYS.accessToken)) {
+    return <Navigate to={ROUTER_PATHS.SIGNIN} />;
+  }
+
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <SuspensedLayout />
+    </Suspense>
+  );
+};
+
+export default AdminLayout;

--- a/src/mocks/datas/member.ts
+++ b/src/mocks/datas/member.ts
@@ -1,6 +1,18 @@
 import { Member } from '@/types/member';
 import { NonNullableFields } from '@/types/utility';
 
+export const AdminMemberInfo: NonNullableFields<Member> = {
+  id: 1,
+  role: 'ADMIN',
+  email: 'admin@gmail.com',
+  nickname: '낯선 바다',
+  gender: 'MALE',
+  birthDay: [1995, 4, 27],
+  age: 28,
+  worryTypes: [],
+  letterCount: 5,
+};
+
 export const EmptyMemberInfo: Member = {
   id: 8,
   email: 'aodem@naver.com',

--- a/src/mocks/handlers/admin.ts
+++ b/src/mocks/handlers/admin.ts
@@ -1,0 +1,24 @@
+import { http } from 'msw';
+import { API_PATHS } from '@/constants/routerPaths';
+import { baseURL } from '@/utils/mswUtils';
+import withAuth from '../middlewares/withAuth';
+import { adminResolvers } from '../resolvers/admin';
+
+const adminHandler = [
+  http.get(
+    baseURL(API_PATHS.ADMIN_MEMBER_SEARCH),
+    withAuth(adminResolvers.getMemberSearch.success),
+  ),
+
+  http.get(
+    baseURL(API_PATHS.ADMIN_REPORT),
+    withAuth(adminResolvers.getReport.success),
+  ),
+
+  http.delete(
+    baseURL(API_PATHS.ADMIN_MEMBER_SEARCH),
+    withAuth(adminResolvers.deleteMember.success),
+  ),
+];
+
+export default adminHandler;

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -3,6 +3,7 @@ import authHandler from './auth';
 import memberHandler from './member';
 import letterHandler from './letter';
 import reportHandler from './report';
+import adminHandler from './admin';
 
 const mockHandlers = [
   ...testHandler,
@@ -10,6 +11,7 @@ const mockHandlers = [
   ...authHandler,
   ...memberHandler,
   ...reportHandler,
+  ...adminHandler,
 ];
 
 export default mockHandlers;

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -8,7 +8,7 @@ const memberHandler = [
   /** 자신의 회원 정보 조회 */
   http.get(
     baseURL(API_PATHS.MEMBER),
-    withAuth(memberResolvers.getMember.success),
+    withAuth(memberResolvers.getMember.admin),
   ),
 
   /** 온보딩 정보 등록 */

--- a/src/mocks/resolvers/admin.ts
+++ b/src/mocks/resolvers/admin.ts
@@ -1,0 +1,67 @@
+import { HttpResponse, delay } from 'msw';
+import { getSearchParams } from '@/utils/mswUtils';
+import { type MSWResolvers } from '@/utils/mswUtils';
+import { PagedMemberResponse, PagedReportResponse } from '@/types/admin';
+import { getRandomItem } from '@/utils/arrayUtils';
+import { NICKNAMES } from '@/constants/users';
+
+export const adminResolvers = {
+  getMemberSearch: {
+    success: async ({ request }) => {
+      await delay();
+      const url = new URL(request.url);
+
+      const itemCount = Number(getSearchParams('mswItemCount')) || 10;
+      const page = Number(url.searchParams.get('page')) || 1;
+
+      const result: PagedMemberResponse = {
+        totalElements: 100,
+        totalPage: 10,
+        hasNextPage: true,
+        members: Array.from({ length: itemCount }, (_, i) => ({
+          id: page * 10 + (i + 1),
+          role: 'USER',
+          email: 'kdo0422@nate.com',
+          nickname: `낯선 ${getRandomItem(NICKNAMES)}`,
+          gender: 'MALE',
+          birthDay: [1999, 4, 22],
+          age: 26,
+        })),
+      };
+
+      return HttpResponse.json(result);
+    },
+  },
+
+  getReport: {
+    success: async ({ request }) => {
+      await delay();
+      const url = new URL(request.url);
+
+      const itemCount = Number(getSearchParams('mswItemCount')) || 10;
+      const page = Number(url.searchParams.get('page')) || 1;
+
+      const result: PagedReportResponse = {
+        totalElements: 100,
+        totalPage: 10,
+        hasNextPage: true,
+        letters: Array.from({ length: itemCount }, (_, i) => ({
+          id: page * 10 + (i + 1),
+          content: '신고 내용',
+          reporterEmail: 'kdo0422@nate.com',
+          reportedEmail: 'oceanLetter1@gmail.com',
+          reportType: 'ABUSE',
+        })),
+      };
+
+      return HttpResponse.json(result);
+    },
+  },
+
+  deleteMember: {
+    success: async () => {
+      await delay();
+      return HttpResponse.json();
+    },
+  },
+} satisfies MSWResolvers;

--- a/src/mocks/resolvers/member.ts
+++ b/src/mocks/resolvers/member.ts
@@ -1,13 +1,18 @@
 import { HttpResponse, delay } from 'msw';
 import ERROR_RESPONSES from '@/constants/errorMessages';
 import { type MSWResolvers } from '@/utils/mswUtils';
-import { EmptyMemberInfo, MemberInfo } from '../datas/member';
+import { AdminMemberInfo, EmptyMemberInfo, MemberInfo } from '../datas/member';
 
 export const memberResolvers = {
   getMember: {
     success: async () => {
       await delay();
       return HttpResponse.json(MemberInfo);
+    },
+
+    admin: async () => {
+      await delay();
+      return HttpResponse.json(AdminMemberInfo);
     },
 
     empty: async () => {

--- a/src/pages/AdminMainPage/components/UserExpelBottomSheet.tsx
+++ b/src/pages/AdminMainPage/components/UserExpelBottomSheet.tsx
@@ -1,0 +1,61 @@
+import { toast } from 'react-toastify';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import adminAPI from '@/api/admin/apis';
+import BottomSheet from '@/components/BottomSheet';
+import Button from '@/components/Button';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import useBoolean from '@/hooks/useBoolean';
+
+interface UserExpelBottomSheetProps extends ReturnType<typeof useBoolean> {
+  expelEmail: string;
+}
+
+const UserExpelBottomSheet = ({
+  expelEmail,
+  value,
+  on,
+  off,
+}: UserExpelBottomSheetProps) => {
+  const { mutate, isPending } = useMutation({
+    mutationFn: adminAPI.deleteMember,
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    },
+  });
+  const queryClient = useQueryClient();
+
+  const handleExpel = () => {
+    mutate(expelEmail, {
+      onSuccess: () => {
+        toast.success('회원을 탈퇴시켰습니다.', { position: 'bottom-center' });
+        off();
+      },
+    });
+  };
+
+  return (
+    <BottomSheet open={value} onOpen={on} onClose={off}>
+      <BottomSheet.Title>회원을 탈퇴시키시겠어요?</BottomSheet.Title>
+      <BottomSheet.Description>
+        <p>회원을 탈퇴시키면 해당 회원의 모든 데이터가 삭제됩니다.</p>
+        <p>정말로 {expelEmail} 회원을 탈퇴시키시겠어요?</p>
+      </BottomSheet.Description>
+      <BottomSheet.Divider />
+      <BottomSheet.ButtonSection>
+        <Button variant="cancel" size="sm" onClick={off}>
+          취소
+        </Button>
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={handleExpel}
+          disabled={isPending}
+        >
+          {isPending ? <LoadingSpinner size="1.25rem" /> : '탈퇴 시키기'}
+        </Button>
+      </BottomSheet.ButtonSection>
+    </BottomSheet>
+  );
+};
+
+export default UserExpelBottomSheet;

--- a/src/pages/AdminMainPage/hooks/usePagedReportQuery.ts
+++ b/src/pages/AdminMainPage/hooks/usePagedReportQuery.ts
@@ -1,0 +1,26 @@
+import { useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import adminOptions from '@/api/admin/queryOptions';
+import useAdminPageStore from '@/stores/useAdminPageStore';
+
+const usePagedReportQuery = (email?: string) => {
+  const [searchParams] = useSearchParams();
+  const page = searchParams.get('page') || '1';
+  const setTotalPage = useAdminPageStore((s) => s.setTotalPage);
+
+  const query = useSuspenseQuery(
+    adminOptions.report({
+      page,
+      reportedEmail: email,
+    }),
+  );
+
+  useEffect(() => {
+    setTotalPage(query.data.totalPage);
+  }, [query.data.totalPage]);
+
+  return query;
+};
+
+export default usePagedReportQuery;

--- a/src/pages/AdminMainPage/hooks/usePagedUserQuery.ts
+++ b/src/pages/AdminMainPage/hooks/usePagedUserQuery.ts
@@ -1,0 +1,26 @@
+import { useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import adminOptions from '@/api/admin/queryOptions';
+import useAdminPageStore from '@/stores/useAdminPageStore';
+
+const usePagedUserQuery = (email?: string) => {
+  const [searchParams] = useSearchParams();
+  const page = searchParams.get('page') || '1';
+  const setTotalPage = useAdminPageStore((s) => s.setTotalPage);
+
+  const query = useSuspenseQuery(
+    adminOptions.member({
+      page,
+      email,
+    }),
+  );
+
+  useEffect(() => {
+    setTotalPage(query.data.totalPage);
+  }, [query.data.totalPage]);
+
+  return query;
+};
+
+export default usePagedUserQuery;

--- a/src/pages/AdminMainPage/index.tsx
+++ b/src/pages/AdminMainPage/index.tsx
@@ -1,0 +1,67 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { css } from '@emotion/react';
+import PaginationBar from '@/components/PaginationBar';
+import Tabs from '@/components/Tabs';
+import Header from '@/components/Header';
+import STORAGE_KEYS from '@/constants/storageKeys';
+import { ROUTER_PATHS } from '@/constants/routerPaths';
+import useAdminPageStore from '@/stores/useAdminPageStore';
+import styles from './style';
+import UserTab from './tabs/UserTab';
+import ReportTab from './tabs/ReportTab';
+
+const AdminMainPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const page = searchParams.get('page') || '1';
+  const navigate = useNavigate();
+  const totalPage = useAdminPageStore((s) => s.totalPage);
+
+  const handleLogout = () => {
+    localStorage.removeItem(STORAGE_KEYS.accessToken);
+    localStorage.removeItem(STORAGE_KEYS.refreshToken);
+    navigate(ROUTER_PATHS.SIGNIN);
+  };
+
+  const handleTabChange = () => {
+    setSearchParams({ ...searchParams, page: '1' });
+  };
+
+  const handlePageChange = (page: number) => {
+    setSearchParams({ ...searchParams, page: page.toString() });
+  };
+
+  return (
+    <div css={styles.container}>
+      <Header>
+        <Header.Center>관리자 페이지</Header.Center>
+        <Header.Right>
+          <p css={css({ cursor: 'pointer' })} onClick={handleLogout}>
+            로그아웃
+          </p>
+        </Header.Right>
+      </Header>
+      <main css={styles.main}>
+        <Tabs defaultValue="user" onValueChange={handleTabChange}>
+          <Tabs.List>
+            <Tabs.Trigger value="user">사용자 관리</Tabs.Trigger>
+            <Tabs.Trigger value="report">신고 관리</Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="user">
+            <UserTab />
+          </Tabs.Content>
+          <Tabs.Content value="report">
+            <ReportTab />
+          </Tabs.Content>
+        </Tabs>
+      </main>
+      <PaginationBar
+        count={totalPage}
+        page={Number(page)}
+        defaultPage={1}
+        onChange={handlePageChange}
+      />
+    </div>
+  );
+};
+
+export default AdminMainPage;

--- a/src/pages/AdminMainPage/style.ts
+++ b/src/pages/AdminMainPage/style.ts
@@ -1,0 +1,40 @@
+import { css } from '@emotion/react';
+import COLORS from '@/constants/colors';
+import textStyles from '@/styles/textStyles';
+
+const styles = {
+  container: css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    min-height: 100svh;
+    padding: 0 1rem 1rem;
+    text-align: center;
+  `,
+  main: css`
+    flex-grow: 1;
+    width: 100%;
+  `,
+  tabContent: css`
+    display: flex;
+    flex-grow: 1;
+    flex-direction: column;
+    margin: 1rem 0;
+  `,
+  input: css`
+    margin-bottom: 1rem;
+    padding: 0.8125rem 1rem;
+    border: 1px solid rgb(255 255 255 / 0.3);
+    border-radius: 0.75rem;
+    color: ${COLORS.gray1};
+    outline: none;
+    text-align: center;
+    backdrop-filter: blur(7.5px);
+
+    ${textStyles.t3}
+  `,
+};
+
+export default styles;

--- a/src/pages/AdminMainPage/tabs/ReportTab.tsx
+++ b/src/pages/AdminMainPage/tabs/ReportTab.tsx
@@ -1,0 +1,109 @@
+import { Suspense, useMemo, useState } from 'react';
+import Paper from '@mui/material/Paper';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import Dropdown from '@/components/Dropdown';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { MoreHorizontal, TrashCan } from '@/assets/icons';
+import COLORS from '@/constants/colors';
+import { REPORT_TYPE_DICT } from '@/constants/report';
+import useBoolean from '@/hooks/useBoolean';
+import { debounce } from '@/utils/timerUtils';
+import usePagedReportQuery from '../hooks/usePagedReportQuery';
+import styles from '../style';
+import UserExpelBottomSheet from '../components/UserExpelBottomSheet';
+
+interface SuspensedReportTabProps {
+  email?: string;
+}
+
+const SuspensedReportTab = ({ email }: SuspensedReportTabProps) => {
+  const { data } = usePagedReportQuery(email);
+  const [expelEmail, setExpelEmail] = useState('');
+  const userExpelBottomSheetProps = useBoolean(false);
+
+  const handleOpenExpelModal = (email: string) => {
+    setExpelEmail(email);
+    userExpelBottomSheetProps.on();
+  };
+
+  return (
+    <>
+      <UserExpelBottomSheet
+        expelEmail={expelEmail}
+        {...userExpelBottomSheetProps}
+      />
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>유형</TableCell>
+              <TableCell>신고 대상</TableCell>
+              <TableCell>제보자</TableCell>
+              <TableCell>신고 내용</TableCell>
+              <TableCell align="right">동작</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.letters.map((letter) => (
+              <TableRow key={letter.id}>
+                <TableCell>{REPORT_TYPE_DICT[letter.reportType]}</TableCell>
+                <TableCell>{letter.reportedEmail}</TableCell>
+                <TableCell>{letter.reporterEmail}</TableCell>
+                <TableCell>{letter.content}</TableCell>
+                <TableCell align="right">
+                  <Dropdown
+                    triggerComponent={<MoreHorizontal />}
+                    options={[
+                      {
+                        icon: <TrashCan width={20} height={20} />,
+                        label: '회원 탈퇴',
+                        onClick: () =>
+                          handleOpenExpelModal(letter.reportedEmail),
+                        color: COLORS.danger,
+                      },
+                    ]}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
+  );
+};
+
+const ReportTab = () => {
+  const [email, setEmail] = useState('');
+
+  const handleDebouncedSearch = useMemo(
+    () =>
+      debounce((e: React.ChangeEvent<HTMLInputElement>) => {
+        setEmail(e.target.value);
+      }, 500),
+    [],
+  );
+
+  return (
+    <div css={styles.tabContent}>
+      <input
+        css={styles.input}
+        onChange={handleDebouncedSearch}
+        placeholder="검색할 이메일을 입력하세요"
+      />
+
+      <Suspense fallback={<LoadingSpinner />}>
+        <SuspensedReportTab email={email} />
+      </Suspense>
+    </div>
+  );
+};
+
+export default ReportTab;

--- a/src/pages/AdminMainPage/tabs/UserTab.tsx
+++ b/src/pages/AdminMainPage/tabs/UserTab.tsx
@@ -1,0 +1,111 @@
+import { Suspense, useMemo, useState } from 'react';
+import Paper from '@mui/material/Paper';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import Dropdown from '@/components/Dropdown';
+import { Copy, MoreHorizontal, TrashCan } from '@/assets/icons';
+import COLORS from '@/constants/colors';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import useBoolean from '@/hooks/useBoolean';
+import { debounce } from '@/utils/timerUtils';
+import usePagedUserQuery from '../hooks/usePagedUserQuery';
+import styles from '../style';
+import UserExpelBottomSheet from '../components/UserExpelBottomSheet';
+
+interface SuspensedUserTabProps {
+  searchEmail: string;
+}
+
+const SuspensedUserTab = ({ searchEmail }: SuspensedUserTabProps) => {
+  const { data } = usePagedUserQuery(searchEmail);
+  const [expelEmail, setExpelEmail] = useState('');
+  const userExpelBottomSheetProps = useBoolean(false);
+
+  const handleOpenExpelModal = (email: string) => {
+    setExpelEmail(email);
+    userExpelBottomSheetProps.on();
+  };
+
+  return (
+    <>
+      <UserExpelBottomSheet
+        expelEmail={expelEmail}
+        {...userExpelBottomSheetProps}
+      />
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>이메일</TableCell>
+              <TableCell>닉네임</TableCell>
+              <TableCell align="right">동작</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.members.map((member) => (
+              <TableRow key={member.id}>
+                <TableCell>{member.email}</TableCell>
+                <TableCell>{member.nickname}</TableCell>
+                <TableCell align="right">
+                  <Dropdown
+                    triggerComponent={<MoreHorizontal />}
+                    options={[
+                      {
+                        icon: <Copy width={20} height={20} />,
+                        label: '편지 보내기',
+                        onClick: () => {
+                          alert('TODO: 편지 보내기는 준비중인 기능이에요');
+                        },
+                        color: COLORS.gray2,
+                      },
+                      {
+                        icon: <TrashCan width={20} height={20} />,
+                        label: '회원 탈퇴',
+                        onClick: () => handleOpenExpelModal(member.email),
+                        color: COLORS.danger,
+                      },
+                    ]}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
+  );
+};
+
+const UserTab = () => {
+  const [email, setEmail] = useState('');
+
+  const handleDebouncedSearch = useMemo(
+    () =>
+      debounce((e: React.ChangeEvent<HTMLInputElement>) => {
+        setEmail(e.target.value);
+      }, 500),
+    [],
+  );
+
+  return (
+    <div css={styles.tabContent}>
+      <input
+        css={styles.input}
+        onChange={handleDebouncedSearch}
+        placeholder="검색할 이메일을 입력하세요"
+      />
+
+      <Suspense fallback={<LoadingSpinner />}>
+        <SuspensedUserTab searchEmail={email} />
+      </Suspense>
+    </div>
+  );
+};
+
+export default UserTab;

--- a/src/pages/LetterStoragePage/index.tsx
+++ b/src/pages/LetterStoragePage/index.tsx
@@ -11,42 +11,36 @@ const LetterStoragePage = () => {
     <div css={style.container}>
       <StorageHeader />
       <div css={style.content}>
-        <Tabs
-          tabItems={[
-            {
-              content: (
-                <Suspense
-                  fallback={
-                    <div css={style.loadingSpinner}>
-                      <LoadingSpinner size="4rem" />
-                      <p>보관한 편지 가져오는 중...</p>
-                    </div>
-                  }
-                >
-                  <ArchiveLetters />
-                </Suspense>
-              ),
-              key: '1',
-              label: '보관한 편지',
-            },
-            {
-              content: (
-                <Suspense
-                  fallback={
-                    <div css={style.loadingSpinner}>
-                      <LoadingSpinner size="4rem" />
-                      <p>내가 쓴 편지 가져오는 중...</p>
-                    </div>
-                  }
-                >
-                  <MySentLetters />
-                </Suspense>
-              ),
-              key: '2',
-              label: '내가 보낸 편지',
-            },
-          ]}
-        />
+        <Tabs variant="primary" defaultValue="1">
+          <Tabs.List>
+            <Tabs.Trigger value="1">보관한 편지</Tabs.Trigger>
+            <Tabs.Trigger value="2">내가 보낸 편지</Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="1">
+            <Suspense
+              fallback={
+                <div css={style.loadingSpinner}>
+                  <LoadingSpinner size="4rem" />
+                  <p>보관한 편지 가져오는 중...</p>
+                </div>
+              }
+            >
+              <ArchiveLetters />
+            </Suspense>
+          </Tabs.Content>
+          <Tabs.Content value="2">
+            <Suspense
+              fallback={
+                <div css={style.loadingSpinner}>
+                  <LoadingSpinner size="4rem" />
+                  <p>내가 쓴 편지 가져오는 중...</p>
+                </div>
+              }
+            >
+              <MySentLetters />
+            </Suspense>
+          </Tabs.Content>
+        </Tabs>
       </div>
     </div>
   );

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,6 +13,9 @@ import LetterReplyPage from './pages/LetterReplyPage';
 import LetterStoragePage from './pages/LetterStoragePage';
 import NotFoundPage from './pages/NotFoundPage';
 import { ROUTER_PATHS } from './constants/routerPaths';
+import AdminLayout from './layouts/AdminLayout';
+import AdminMainPage from './pages/AdminMainPage';
+import AdminApp from './AdminApp';
 
 const router = createBrowserRouter([
   {
@@ -68,6 +71,26 @@ const router = createBrowserRouter([
           {
             path: ROUTER_PATHS.LETTER_STORAGE,
             element: <LetterStoragePage />,
+          },
+        ],
+      },
+      {
+        path: '*',
+        element: <NotFoundPage />,
+      },
+    ],
+  },
+  {
+    path: '/',
+    element: <AdminApp />,
+    children: [
+      {
+        path: '/',
+        element: <AdminLayout />,
+        children: [
+          {
+            path: ROUTER_PATHS.ADMIN,
+            element: <AdminMainPage />,
           },
         ],
       },

--- a/src/stores/useAdminPageStore.ts
+++ b/src/stores/useAdminPageStore.ts
@@ -1,0 +1,19 @@
+import { createStore, useStore } from 'zustand';
+
+type State = {
+  totalPage: number;
+};
+
+type Action = {
+  setTotalPage: (totalPage: number) => void;
+};
+
+export const adminPageStore = createStore<State & Action>((set) => ({
+  totalPage: 1,
+  setTotalPage: (totalPage) => set({ totalPage }),
+}));
+
+const useAdminPageStore = <T>(selector: (state: State & Action) => T) =>
+  useStore(adminPageStore, selector);
+
+export default useAdminPageStore;

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,0 +1,17 @@
+import { type ReportType } from '@/constants/report';
+import { type Pagination } from './pagination';
+import { type Member } from './member';
+
+export type PagedReportResponse = Pagination & {
+  letters: {
+    id: number;
+    reporterEmail: string;
+    reportedEmail: string;
+    reportType: ReportType;
+    content: string;
+  }[];
+};
+
+export type PagedMemberResponse = Pagination & {
+  members: Omit<Member, 'worryTypes' | 'letterCount'>[];
+};

--- a/src/types/letter.ts
+++ b/src/types/letter.ts
@@ -1,4 +1,5 @@
 import { type Worry } from '@/constants/letters';
+import { type Pagination } from './pagination';
 
 export type Letter = {
   content: string;
@@ -42,10 +43,7 @@ export type Reply = {
   replyImagePath: string | null;
 };
 
-export type Storage = {
-  totalElements: number;
-  totalPage: number;
-  hasNextPage: boolean;
+export type Storage = Pagination & {
   letters: Reply[];
 };
 
@@ -59,9 +57,6 @@ export type SendLetter = {
   sendImagePath: string | null;
 };
 
-export type Send = {
-  totalElements: number;
-  totalPage: number;
-  hasNextPage: boolean;
+export type Send = Pagination & {
   letters: SendLetter[];
 };

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,0 +1,5 @@
+export type Pagination = {
+  totalElements: number;
+  totalPage: number;
+  hasNextPage: boolean;
+};

--- a/src/utils/timerUtils.ts
+++ b/src/utils/timerUtils.ts
@@ -1,0 +1,22 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const debounce = <Callback extends (...args: any[]) => any>(
+  callback: Callback,
+  delay: number = 300,
+) => {
+  let timeout: NodeJS.Timeout;
+
+  return (...args: Parameters<Callback>): ReturnType<Callback> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let result: any;
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(() => {
+      result = callback.apply(this, args);
+    }, delay);
+
+    return result;
+  };
+};


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #259 

## ✅ 작업 사항
Tabs 컴포넌트를 합성 컴포넌트 방식으로 리팩토링했어요.

## 👩‍💻 공유 포인트 및 논의 사항
### 인터페이스 변경 사항
기존에 tabItems 배열 아이템의 `key` 대신, radix ui에서 사용하는 `value` 이름으로 변경했어요.

```tsx
    <Tabs {...args}>
      <Tabs.List>
        <Tabs.Trigger value="tab1">One</Tabs.Trigger>
        <Tabs.Trigger value="tab2">Two</Tabs.Trigger>
        <Tabs.Trigger value="tab3">Three</Tabs.Trigger>
      </Tabs.List>
      <Tabs.Content value="tab1">Tab one content</Tabs.Content>
      <Tabs.Content value="tab2">Tab two content</Tabs.Content>
      <Tabs.Content value="tab3">Tab three content</Tabs.Content>
    </Tabs>
```