### PR TITLE
✨ feat: 관리자 페이지 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "clsx": "^2.1.0",
         "embla-carousel-react": "^8.0.0-rc22",
         "framer-motion": "^10.18.0",
+        "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.12",
@@ -13628,6 +13629,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clsx": "^2.1.0",
     "embla-carousel-react": "^8.0.0-rc22",
     "framer-motion": "^10.18.0",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.12",

--- a/src/AdminApp.tsx
+++ b/src/AdminApp.tsx
@@ -12,26 +12,20 @@ import 'react-toastify/dist/ReactToastify.css';
 const AdminApp = () => {
   return (
     <Background imageUrl={BackgroundImg}>
-      <div css={styles.root}>
-        <UnknownErrorBoundary FallbackComponent={RootUnknownFallback}>
-          <ApiErrorBoundary FallbackComponent={RootApiFallback}>
-            <Outlet />
-          </ApiErrorBoundary>
-        </UnknownErrorBoundary>
-        <ToastContainer
-          css={css({
-            margin: '4rem 0 5rem 0',
-            padding: '0 1rem',
-            boxSizing: 'border-box',
-          })}
-        />
-      </div>
+      <UnknownErrorBoundary FallbackComponent={RootUnknownFallback}>
+        <ApiErrorBoundary FallbackComponent={RootApiFallback}>
+          <Outlet />
+        </ApiErrorBoundary>
+      </UnknownErrorBoundary>
+      <ToastContainer
+        css={css({
+          margin: '4rem 0 5rem 0',
+          padding: '0 1rem',
+          boxSizing: 'border-box',
+        })}
+      />
     </Background>
   );
-};
-
-const styles = {
-  root: css``,
 };
 
 export default AdminApp;

--- a/src/AdminApp.tsx
+++ b/src/AdminApp.tsx
@@ -1,0 +1,37 @@
+import { Outlet } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
+import { css } from '@emotion/react';
+import Background from '@/components/Background';
+import BackgroundImg from '@/assets/background.png';
+import UnknownErrorBoundary from '@/components/ErrorBoundary/UnknownErrorBoundary';
+import ApiErrorBoundary from '@/components/ErrorBoundary/ApiErrorBoundary';
+import RootApiFallback from './components/ErrorBoundary/fallback/RootApiFallback';
+import RootUnknownFallback from './components/ErrorBoundary/fallback/RootUnknownFallback';
+import 'react-toastify/dist/ReactToastify.css';
+
+const AdminApp = () => {
+  return (
+    <Background imageUrl={BackgroundImg}>
+      <div css={styles.root}>
+        <UnknownErrorBoundary FallbackComponent={RootUnknownFallback}>
+          <ApiErrorBoundary FallbackComponent={RootApiFallback}>
+            <Outlet />
+          </ApiErrorBoundary>
+        </UnknownErrorBoundary>
+        <ToastContainer
+          css={css({
+            margin: '4rem 0 5rem 0',
+            padding: '0 1rem',
+            boxSizing: 'border-box',
+          })}
+        />
+      </div>
+    </Background>
+  );
+};
+
+const styles = {
+  root: css``,
+};
+
+export default AdminApp;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,21 +14,34 @@ import 'react-toastify/dist/ReactToastify.css';
 const App = () => {
   return (
     <Background imageUrl={BackgroundImg}>
-      <UnknownErrorBoundary FallbackComponent={RootUnknownFallback}>
-        <ApiErrorBoundary FallbackComponent={RootApiFallback}>
-          <Outlet />
-        </ApiErrorBoundary>
-      </UnknownErrorBoundary>
-      <Audio src={BackgroundMusic} />
-      <ToastContainer
-        css={css({
-          margin: '4rem 0 5rem 0',
-          padding: '0 1rem',
-          boxSizing: 'border-box',
-        })}
-      />
+      <div css={styles.root}>
+        <UnknownErrorBoundary FallbackComponent={RootUnknownFallback}>
+          <ApiErrorBoundary FallbackComponent={RootApiFallback}>
+            <Outlet />
+          </ApiErrorBoundary>
+        </UnknownErrorBoundary>
+        <Audio src={BackgroundMusic} />
+        <ToastContainer
+          css={css({
+            margin: '4rem 0 5rem 0',
+            padding: '0 1rem',
+            boxSizing: 'border-box',
+          })}
+        />
+      </div>
     </Background>
   );
+};
+
+const styles = {
+  root: css`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 600px;
+    margin: 0 auto;
+  `,
 };
 
 export default App;

--- a/src/api/admin/apis.ts
+++ b/src/api/admin/apis.ts
@@ -6,25 +6,21 @@ import {
 import { authInstance } from '../instance';
 
 const adminAPI = {
-  getReport: async (email?: string) => {
+  getReport: async (params?: { page?: string; email?: string }) => {
     const { data } = await authInstance.get<PagedReportResponse>(
       API_PATHS.ADMIN_REPORT,
       {
-        params: {
-          email,
-        },
+        params,
       },
     );
     return data;
   },
 
-  getMemberSearch: async (email: string) => {
+  getMemberSearch: async (params?: { page?: string; email?: string }) => {
     const { data } = await authInstance.get<PagedMemberResponse>(
       API_PATHS.ADMIN_MEMBER_SEARCH,
       {
-        params: {
-          email,
-        },
+        params,
       },
     );
     return data;

--- a/src/api/admin/apis.ts
+++ b/src/api/admin/apis.ts
@@ -1,0 +1,72 @@
+import { API_PATHS } from '@/constants/routerPaths';
+import {
+  type PagedMemberResponse,
+  type PagedReportResponse,
+} from '@/types/admin';
+import { authInstance } from '../instance';
+
+const adminAPI = {
+  getReport: async (email?: string) => {
+    const { data } = await authInstance.get<PagedReportResponse>(
+      API_PATHS.ADMIN_REPORT,
+      {
+        params: {
+          email,
+        },
+      },
+    );
+    return data;
+  },
+
+  getMemberSearch: async (email: string) => {
+    const { data } = await authInstance.get<PagedMemberResponse>(
+      API_PATHS.ADMIN_MEMBER_SEARCH,
+      {
+        params: {
+          email,
+        },
+      },
+    );
+    return data;
+  },
+
+  deleteMember: async (email: string) => {
+    const { data } = await authInstance.delete(API_PATHS.ADMIN_MEMBER_SEARCH, {
+      params: {
+        email,
+      },
+    });
+    return data;
+  },
+
+  postSpecialLetter: async ({
+    content,
+    email,
+    image,
+  }: {
+    email: string;
+    content: string;
+    image?: File;
+  }) => {
+    const formData = new FormData();
+    formData.append('content', content);
+    formData.append('email', email);
+
+    if (image) {
+      formData.append('image', image);
+    }
+
+    const { data } = await authInstance.post(
+      API_PATHS.ADMIN_LETTER_SPECIAL,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    );
+    return data;
+  },
+};
+
+export default adminAPI;

--- a/src/api/admin/queryOptions.ts
+++ b/src/api/admin/queryOptions.ts
@@ -1,0 +1,20 @@
+import { queryOptions } from '@tanstack/react-query';
+import adminAPI from './apis';
+
+const adminOptions = {
+  all: ['admin'] as const,
+
+  member: (params?: { page?: string; email?: string }) =>
+    queryOptions({
+      queryKey: [...adminOptions.all, 'member', params] as const,
+      queryFn: () => adminAPI.getMemberSearch(params),
+    }),
+
+  report: (params?: { page?: string; reportedEmail?: string }) =>
+    queryOptions({
+      queryKey: [...adminOptions.all, 'report', params] as const,
+      queryFn: () => adminAPI.getReport(params),
+    }),
+};
+
+export default adminOptions;

--- a/src/components/Background/index.tsx
+++ b/src/components/Background/index.tsx
@@ -7,11 +7,7 @@ interface BackgroundProps extends React.ComponentPropsWithoutRef<'div'> {
 }
 
 const Background = ({ imageUrl, children }: BackgroundProps) => {
-  return (
-    <div css={styles.background(imageUrl)}>
-      <div css={styles.wrapper}>{children}</div>
-    </div>
-  );
+  return <div css={styles.background(imageUrl)}>{children}</div>;
 };
 
 export default Background;

--- a/src/components/Background/styles.ts
+++ b/src/components/Background/styles.ts
@@ -63,15 +63,6 @@ const style = {
       animation-duration: 40000s;
     }
   `,
-
-  wrapper: css`
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
-    max-width: 600px;
-    margin: 0 auto;
-  `,
 };
 
 export default style;

--- a/src/components/PaginationBar/index.tsx
+++ b/src/components/PaginationBar/index.tsx
@@ -4,6 +4,8 @@ import IconButton from '../IconButton';
 import styles from './style';
 
 interface PaginationBarProps {
+  /** 현재 페이지 번호 */
+  page?: number;
   /** 기본 페이지 번호 */
   defaultPage: number;
   /** 페이지 갯수 */
@@ -13,6 +15,7 @@ interface PaginationBarProps {
 }
 
 const PaginationBar = ({
+  page,
   defaultPage,
   count,
   onChange = () => {},
@@ -20,6 +23,7 @@ const PaginationBar = ({
   const { items } = usePagination({
     siblingCount: 0,
     boundaryCount: 1,
+    page,
     defaultPage,
     count,
     onChange: (_, page) => onChange(page),

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -11,14 +11,28 @@ interface TabsProps {
   variant?: TabsVariant;
   /** 기본으로 활성화 되어 있을 탭 아이템의 key를 지정합니다.  */
   defaultValue?: string;
+  /** 탭 아이템이 변경될 때 호출되는 콜백 함수입니다. */
+  onValueChange?: (value: string) => void;
   /** Tabs 컴포넌트 안에 포함될 내용입니다. */
   children?: React.ReactNode;
 }
 
-const Tabs = ({ variant = 'primary', defaultValue, children }: TabsProps) => {
+const Tabs = ({
+  variant = 'primary',
+  defaultValue,
+  onValueChange,
+  children,
+  ...props
+}: TabsProps) => {
   return (
     <TabsProvider value={{ variant }}>
-      <T.Root defaultValue={defaultValue}>{children}</T.Root>
+      <T.Root
+        defaultValue={defaultValue}
+        onValueChange={onValueChange}
+        {...props}
+      >
+        {children}
+      </T.Root>
     </TabsProvider>
   );
 };

--- a/src/constants/routerPaths.ts
+++ b/src/constants/routerPaths.ts
@@ -37,6 +37,10 @@ export const API_PATHS = {
     `/api/letter/send/${letterId}` as const,
 
   REPORT_SEND: '/api/report',
+
+  ADMIN_REPORT: '/api/report',
+  ADMIN_MEMBER_SEARCH: '/api/member/search',
+  ADMIN_LETTER_SPECIAL: '/api/letter/special',
 } as const;
 
 export const ROUTER_PATHS = {

--- a/src/constants/routerPaths.ts
+++ b/src/constants/routerPaths.ts
@@ -53,4 +53,5 @@ export const ROUTER_PATHS = {
   MYPAGE: '/mypage',
   LETTER_REPLY: (letterId: string) => `/reply/${letterId}` as const,
   LETTER_STORAGE: `/storage`,
+  ADMIN: '/admin',
 } as const;

--- a/src/constants/users.ts
+++ b/src/constants/users.ts
@@ -42,6 +42,7 @@ export const GENDER_DICT = {
 
 export const ROLE_DICT = {
   USER: '사용자',
+  ADMIN: '관리자',
 } as const;
 
 export type Nickname = (typeof NICKNAMES)[number];

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { ROUTER_PATHS } from '@/constants/routerPaths';
+import STORAGE_KEYS from '@/constants/storageKeys';
+import LoadingScreen from '@/components/LoadingScreen';
+import memberOptions from '@/api/member/queryOptions';
+
+const SuspensedLayout = () => {
+  const { data } = useSuspenseQuery(memberOptions.detail());
+
+  if (data.role !== 'ADMIN') {
+    return <Navigate to={ROUTER_PATHS.SIGNIN} />;
+  }
+
+  return <Outlet />;
+};
+
+const AdminLayout = () => {
+  if (!localStorage.getItem(STORAGE_KEYS.accessToken)) {
+    return <Navigate to={ROUTER_PATHS.SIGNIN} />;
+  }
+
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <SuspensedLayout />
+    </Suspense>
+  );
+};
+
+export default AdminLayout;

--- a/src/mocks/datas/member.ts
+++ b/src/mocks/datas/member.ts
@@ -1,6 +1,18 @@
 import { Member } from '@/types/member';
 import { NonNullableFields } from '@/types/utility';
 
+export const AdminMemberInfo: NonNullableFields<Member> = {
+  id: 1,
+  role: 'ADMIN',
+  email: 'admin@gmail.com',
+  nickname: '낯선 바다',
+  gender: 'MALE',
+  birthDay: [1995, 4, 27],
+  age: 28,
+  worryTypes: [],
+  letterCount: 5,
+};
+
 export const EmptyMemberInfo: Member = {
   id: 8,
   email: 'aodem@naver.com',

--- a/src/mocks/handlers/admin.ts
+++ b/src/mocks/handlers/admin.ts
@@ -1,0 +1,19 @@
+import { http } from 'msw';
+import { API_PATHS } from '@/constants/routerPaths';
+import { baseURL } from '@/utils/mswUtils';
+import withAuth from '../middlewares/withAuth';
+import { adminResolvers } from '../resolvers/admin';
+
+const adminHandler = [
+  http.get(
+    baseURL(API_PATHS.ADMIN_MEMBER_SEARCH),
+    withAuth(adminResolvers.getMemberSearch.success),
+  ),
+
+  http.get(
+    baseURL(API_PATHS.ADMIN_REPORT),
+    withAuth(adminResolvers.getReport.success),
+  ),
+];
+
+export default adminHandler;

--- a/src/mocks/handlers/admin.ts
+++ b/src/mocks/handlers/admin.ts
@@ -14,6 +14,11 @@ const adminHandler = [
     baseURL(API_PATHS.ADMIN_REPORT),
     withAuth(adminResolvers.getReport.success),
   ),
+
+  http.delete(
+    baseURL(API_PATHS.ADMIN_MEMBER_SEARCH),
+    withAuth(adminResolvers.deleteMember.success),
+  ),
 ];
 
 export default adminHandler;

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -3,6 +3,7 @@ import authHandler from './auth';
 import memberHandler from './member';
 import letterHandler from './letter';
 import reportHandler from './report';
+import adminHandler from './admin';
 
 const mockHandlers = [
   ...testHandler,
@@ -10,6 +11,7 @@ const mockHandlers = [
   ...authHandler,
   ...memberHandler,
   ...reportHandler,
+  ...adminHandler,
 ];
 
 export default mockHandlers;

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -8,7 +8,7 @@ const memberHandler = [
   /** 자신의 회원 정보 조회 */
   http.get(
     baseURL(API_PATHS.MEMBER),
-    withAuth(memberResolvers.getMember.success),
+    withAuth(memberResolvers.getMember.admin),
   ),
 
   /** 온보딩 정보 등록 */

--- a/src/mocks/resolvers/admin.ts
+++ b/src/mocks/resolvers/admin.ts
@@ -1,0 +1,60 @@
+import { HttpResponse, delay } from 'msw';
+import { getSearchParams } from '@/utils/mswUtils';
+import { type MSWResolvers } from '@/utils/mswUtils';
+import { PagedMemberResponse, PagedReportResponse } from '@/types/admin';
+import { getRandomItem } from '@/utils/arrayUtils';
+import { NICKNAMES } from '@/constants/users';
+
+export const adminResolvers = {
+  getMemberSearch: {
+    success: async ({ request }) => {
+      await delay();
+      const url = new URL(request.url);
+
+      const itemCount = Number(getSearchParams('mswItemCount')) || 10;
+      const page = Number(url.searchParams.get('page')) || 1;
+
+      const result: PagedMemberResponse = {
+        totalElements: 100,
+        totalPage: 10,
+        hasNextPage: true,
+        members: Array.from({ length: itemCount }, (_, i) => ({
+          id: page * 10 + (i + 1),
+          role: 'USER',
+          email: 'kdo0422@nate.com',
+          nickname: `낯선 ${getRandomItem(NICKNAMES)}`,
+          gender: 'MALE',
+          birthDay: [1999, 4, 22],
+          age: 26,
+        })),
+      };
+
+      return HttpResponse.json(result);
+    },
+  },
+
+  getReport: {
+    success: async ({ request }) => {
+      await delay();
+      const url = new URL(request.url);
+
+      const itemCount = Number(getSearchParams('mswItemCount')) || 10;
+      const page = Number(url.searchParams.get('page')) || 1;
+
+      const result: PagedReportResponse = {
+        totalElements: 100,
+        totalPage: 10,
+        hasNextPage: true,
+        letters: Array.from({ length: itemCount }, (_, i) => ({
+          id: page * 10 + (i + 1),
+          content: '신고 내용',
+          reporterEmail: 'kdo0422@nate.com',
+          reportedEmail: 'oceanLetter1@gmail.com',
+          reportType: 'ABUSE',
+        })),
+      };
+
+      return HttpResponse.json(result);
+    },
+  },
+} satisfies MSWResolvers;

--- a/src/mocks/resolvers/admin.ts
+++ b/src/mocks/resolvers/admin.ts
@@ -57,4 +57,11 @@ export const adminResolvers = {
       return HttpResponse.json(result);
     },
   },
+
+  deleteMember: {
+    success: async () => {
+      await delay();
+      return HttpResponse.json();
+    },
+  },
 } satisfies MSWResolvers;

--- a/src/mocks/resolvers/member.ts
+++ b/src/mocks/resolvers/member.ts
@@ -1,13 +1,18 @@
 import { HttpResponse, delay } from 'msw';
 import ERROR_RESPONSES from '@/constants/errorMessages';
 import { type MSWResolvers } from '@/utils/mswUtils';
-import { EmptyMemberInfo, MemberInfo } from '../datas/member';
+import { AdminMemberInfo, EmptyMemberInfo, MemberInfo } from '../datas/member';
 
 export const memberResolvers = {
   getMember: {
     success: async () => {
       await delay();
       return HttpResponse.json(MemberInfo);
+    },
+
+    admin: async () => {
+      await delay();
+      return HttpResponse.json(AdminMemberInfo);
     },
 
     empty: async () => {

--- a/src/pages/AdminMainPage/components/UserExpelBottomSheet.tsx
+++ b/src/pages/AdminMainPage/components/UserExpelBottomSheet.tsx
@@ -1,0 +1,61 @@
+import { toast } from 'react-toastify';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import adminAPI from '@/api/admin/apis';
+import BottomSheet from '@/components/BottomSheet';
+import Button from '@/components/Button';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import useBoolean from '@/hooks/useBoolean';
+
+interface UserExpelBottomSheetProps extends ReturnType<typeof useBoolean> {
+  expelEmail: string;
+}
+
+const UserExpelBottomSheet = ({
+  expelEmail,
+  value,
+  on,
+  off,
+}: UserExpelBottomSheetProps) => {
+  const { mutate, isPending } = useMutation({
+    mutationFn: adminAPI.deleteMember,
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    },
+  });
+  const queryClient = useQueryClient();
+
+  const handleExpel = () => {
+    mutate(expelEmail, {
+      onSuccess: () => {
+        toast.success('회원을 탈퇴시켰습니다.', { position: 'bottom-center' });
+        off();
+      },
+    });
+  };
+
+  return (
+    <BottomSheet open={value} onOpen={on} onClose={off}>
+      <BottomSheet.Title>회원을 탈퇴시키시겠어요?</BottomSheet.Title>
+      <BottomSheet.Description>
+        <p>회원을 탈퇴시키면 해당 회원의 모든 데이터가 삭제됩니다.</p>
+        <p>정말로 {expelEmail} 회원을 탈퇴시키시겠어요?</p>
+      </BottomSheet.Description>
+      <BottomSheet.Divider />
+      <BottomSheet.ButtonSection>
+        <Button variant="cancel" size="sm" onClick={off}>
+          취소
+        </Button>
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={handleExpel}
+          disabled={isPending}
+        >
+          {isPending ? <LoadingSpinner size="1.25rem" /> : '탈퇴 시키기'}
+        </Button>
+      </BottomSheet.ButtonSection>
+    </BottomSheet>
+  );
+};
+
+export default UserExpelBottomSheet;

--- a/src/pages/AdminMainPage/hooks/usePagedReportQuery.ts
+++ b/src/pages/AdminMainPage/hooks/usePagedReportQuery.ts
@@ -1,0 +1,26 @@
+import { useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import adminOptions from '@/api/admin/queryOptions';
+import useAdminPageStore from '@/stores/useAdminPageStore';
+
+const usePagedReportQuery = (email?: string) => {
+  const [searchParams] = useSearchParams();
+  const page = searchParams.get('page') || '1';
+  const setTotalPage = useAdminPageStore((s) => s.setTotalPage);
+
+  const query = useSuspenseQuery(
+    adminOptions.report({
+      page,
+      reportedEmail: email,
+    }),
+  );
+
+  useEffect(() => {
+    setTotalPage(query.data.totalPage);
+  }, [query.data.totalPage]);
+
+  return query;
+};
+
+export default usePagedReportQuery;

--- a/src/pages/AdminMainPage/hooks/usePagedUserQuery.ts
+++ b/src/pages/AdminMainPage/hooks/usePagedUserQuery.ts
@@ -1,0 +1,26 @@
+import { useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import adminOptions from '@/api/admin/queryOptions';
+import useAdminPageStore from '@/stores/useAdminPageStore';
+
+const usePagedUserQuery = (email?: string) => {
+  const [searchParams] = useSearchParams();
+  const page = searchParams.get('page') || '1';
+  const setTotalPage = useAdminPageStore((s) => s.setTotalPage);
+
+  const query = useSuspenseQuery(
+    adminOptions.member({
+      page,
+      email,
+    }),
+  );
+
+  useEffect(() => {
+    setTotalPage(query.data.totalPage);
+  }, [query.data.totalPage]);
+
+  return query;
+};
+
+export default usePagedUserQuery;

--- a/src/pages/AdminMainPage/index.tsx
+++ b/src/pages/AdminMainPage/index.tsx
@@ -1,21 +1,33 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { css } from '@emotion/react';
 import PaginationBar from '@/components/PaginationBar';
 import Tabs from '@/components/Tabs';
 import Header from '@/components/Header';
 import STORAGE_KEYS from '@/constants/storageKeys';
 import { ROUTER_PATHS } from '@/constants/routerPaths';
+import useAdminPageStore from '@/stores/useAdminPageStore';
 import styles from './style';
 import UserTab from './tabs/UserTab';
 import ReportTab from './tabs/ReportTab';
 
 const AdminMainPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const page = searchParams.get('page') || '1';
   const navigate = useNavigate();
+  const totalPage = useAdminPageStore((s) => s.totalPage);
 
   const handleLogout = () => {
     localStorage.removeItem(STORAGE_KEYS.accessToken);
     localStorage.removeItem(STORAGE_KEYS.refreshToken);
     navigate(ROUTER_PATHS.SIGNIN);
+  };
+
+  const handleTabChange = () => {
+    setSearchParams({ ...searchParams, page: '1' });
+  };
+
+  const handlePageChange = (page: number) => {
+    setSearchParams({ ...searchParams, page: page.toString() });
   };
 
   return (
@@ -29,7 +41,7 @@ const AdminMainPage = () => {
         </Header.Right>
       </Header>
       <main css={styles.main}>
-        <Tabs>
+        <Tabs defaultValue="user" onValueChange={handleTabChange}>
           <Tabs.List>
             <Tabs.Trigger value="user">사용자 관리</Tabs.Trigger>
             <Tabs.Trigger value="report">신고 관리</Tabs.Trigger>
@@ -42,7 +54,12 @@ const AdminMainPage = () => {
           </Tabs.Content>
         </Tabs>
       </main>
-      <PaginationBar count={100} defaultPage={1} />
+      <PaginationBar
+        count={totalPage}
+        page={Number(page)}
+        defaultPage={1}
+        onChange={handlePageChange}
+      />
     </div>
   );
 };

--- a/src/pages/AdminMainPage/index.tsx
+++ b/src/pages/AdminMainPage/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const AdminMainPage = () => {
+  return <div>관리자 페이지</div>;
+};
+
+export default AdminMainPage;

--- a/src/pages/AdminMainPage/index.tsx
+++ b/src/pages/AdminMainPage/index.tsx
@@ -1,7 +1,50 @@
-import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { css } from '@emotion/react';
+import PaginationBar from '@/components/PaginationBar';
+import Tabs from '@/components/Tabs';
+import Header from '@/components/Header';
+import STORAGE_KEYS from '@/constants/storageKeys';
+import { ROUTER_PATHS } from '@/constants/routerPaths';
+import styles from './style';
+import UserTab from './tabs/UserTab';
+import ReportTab from './tabs/ReportTab';
 
 const AdminMainPage = () => {
-  return <div>관리자 페이지</div>;
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    localStorage.removeItem(STORAGE_KEYS.accessToken);
+    localStorage.removeItem(STORAGE_KEYS.refreshToken);
+    navigate(ROUTER_PATHS.SIGNIN);
+  };
+
+  return (
+    <div css={styles.container}>
+      <Header>
+        <Header.Center>관리자 페이지</Header.Center>
+        <Header.Right>
+          <p css={css({ cursor: 'pointer' })} onClick={handleLogout}>
+            로그아웃
+          </p>
+        </Header.Right>
+      </Header>
+      <main css={styles.main}>
+        <Tabs>
+          <Tabs.List>
+            <Tabs.Trigger value="user">사용자 관리</Tabs.Trigger>
+            <Tabs.Trigger value="report">신고 관리</Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="user">
+            <UserTab />
+          </Tabs.Content>
+          <Tabs.Content value="report">
+            <ReportTab />
+          </Tabs.Content>
+        </Tabs>
+      </main>
+      <PaginationBar count={100} defaultPage={1} />
+    </div>
+  );
 };
 
 export default AdminMainPage;

--- a/src/pages/AdminMainPage/style.ts
+++ b/src/pages/AdminMainPage/style.ts
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+
+const styles = {
+  container: css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    min-height: 100svh;
+    padding: 0 1rem 1rem;
+    text-align: center;
+  `,
+  main: css`
+    flex-grow: 1;
+    width: 100%;
+  `,
+  tabContent: css`
+    margin-top: 1rem;
+  `,
+};
+
+export default styles;

--- a/src/pages/AdminMainPage/style.ts
+++ b/src/pages/AdminMainPage/style.ts
@@ -1,4 +1,6 @@
 import { css } from '@emotion/react';
+import COLORS from '@/constants/colors';
+import textStyles from '@/styles/textStyles';
 
 const styles = {
   container: css`
@@ -16,7 +18,22 @@ const styles = {
     width: 100%;
   `,
   tabContent: css`
-    margin-top: 1rem;
+    display: flex;
+    flex-grow: 1;
+    flex-direction: column;
+    margin: 1rem 0;
+  `,
+  input: css`
+    margin-bottom: 1rem;
+    padding: 0.8125rem 1rem;
+    border: 1px solid rgb(255 255 255 / 0.3);
+    border-radius: 0.75rem;
+    color: ${COLORS.gray1};
+    outline: none;
+    text-align: center;
+    backdrop-filter: blur(7.5px);
+
+    ${textStyles.t3}
   `,
 };
 

--- a/src/pages/AdminMainPage/tabs/ReportTab.tsx
+++ b/src/pages/AdminMainPage/tabs/ReportTab.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import Paper from '@mui/material/Paper';
 import {
   Table,
@@ -14,6 +14,7 @@ import { MoreHorizontal, TrashCan } from '@/assets/icons';
 import COLORS from '@/constants/colors';
 import { REPORT_TYPE_DICT } from '@/constants/report';
 import useBoolean from '@/hooks/useBoolean';
+import { debounce } from '@/utils/timerUtils';
 import usePagedReportQuery from '../hooks/usePagedReportQuery';
 import styles from '../style';
 import UserExpelBottomSheet from '../components/UserExpelBottomSheet';
@@ -82,12 +83,19 @@ const SuspensedReportTab = ({ email }: SuspensedReportTabProps) => {
 const ReportTab = () => {
   const [email, setEmail] = useState('');
 
+  const handleDebouncedSearch = useMemo(
+    () =>
+      debounce((e: React.ChangeEvent<HTMLInputElement>) => {
+        setEmail(e.target.value);
+      }, 500),
+    [],
+  );
+
   return (
     <div css={styles.tabContent}>
       <input
         css={styles.input}
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
+        onChange={handleDebouncedSearch}
         placeholder="검색할 이메일을 입력하세요"
       />
 

--- a/src/pages/AdminMainPage/tabs/ReportTab.tsx
+++ b/src/pages/AdminMainPage/tabs/ReportTab.tsx
@@ -1,7 +1,95 @@
+import { Suspense, useState } from 'react';
+import Paper from '@mui/material/Paper';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import Dropdown from '@/components/Dropdown';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { Copy, MoreHorizontal, TrashCan } from '@/assets/icons';
+import COLORS from '@/constants/colors';
+import { REPORT_TYPE_DICT } from '@/constants/report';
+import usePagedReportQuery from '../hooks/usePagedReportQuery';
 import styles from '../style';
 
+interface SuspensedReportTabProps {
+  email?: string;
+}
+
+const SuspensedReportTab = ({ email }: SuspensedReportTabProps) => {
+  const { data } = usePagedReportQuery(email);
+
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>유형</TableCell>
+            <TableCell>신고 대상</TableCell>
+            <TableCell>제보자</TableCell>
+            <TableCell>신고 내용</TableCell>
+            <TableCell align="right">동작</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.letters.map((letter) => (
+            <TableRow key={letter.id}>
+              <TableCell>{REPORT_TYPE_DICT[letter.reportType]}</TableCell>
+              <TableCell>{letter.reportedEmail}</TableCell>
+              <TableCell>{letter.reporterEmail}</TableCell>
+              <TableCell>{letter.content}</TableCell>
+              <TableCell align="right">
+                <Dropdown
+                  triggerComponent={<MoreHorizontal />}
+                  options={[
+                    {
+                      icon: <Copy width={20} height={20} />,
+                      label: '복사하기',
+                      onClick: () => {
+                        console.log('복사히기 클릭');
+                      },
+                      color: COLORS.gray2,
+                    },
+                    {
+                      icon: <TrashCan width={20} height={20} />,
+                      label: '삭제하기',
+                      onClick: () => {
+                        console.log('삭제하기 클릭');
+                      },
+                      color: COLORS.danger,
+                    },
+                  ]}
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
 const ReportTab = () => {
-  return <div css={styles.tabContent}>ReportTab</div>;
+  const [email, setEmail] = useState('');
+
+  return (
+    <div css={styles.tabContent}>
+      <input
+        css={styles.input}
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="검색할 이메일을 입력하세요"
+      />
+
+      <Suspense fallback={<LoadingSpinner />}>
+        <SuspensedReportTab email={email} />
+      </Suspense>
+    </div>
+  );
 };
 
 export default ReportTab;

--- a/src/pages/AdminMainPage/tabs/ReportTab.tsx
+++ b/src/pages/AdminMainPage/tabs/ReportTab.tsx
@@ -10,11 +10,13 @@ import {
 } from '@mui/material';
 import Dropdown from '@/components/Dropdown';
 import LoadingSpinner from '@/components/LoadingSpinner';
-import { Copy, MoreHorizontal, TrashCan } from '@/assets/icons';
+import { MoreHorizontal, TrashCan } from '@/assets/icons';
 import COLORS from '@/constants/colors';
 import { REPORT_TYPE_DICT } from '@/constants/report';
+import useBoolean from '@/hooks/useBoolean';
 import usePagedReportQuery from '../hooks/usePagedReportQuery';
 import styles from '../style';
+import UserExpelBottomSheet from '../components/UserExpelBottomSheet';
 
 interface SuspensedReportTabProps {
   email?: string;
@@ -22,54 +24,58 @@ interface SuspensedReportTabProps {
 
 const SuspensedReportTab = ({ email }: SuspensedReportTabProps) => {
   const { data } = usePagedReportQuery(email);
+  const [expelEmail, setExpelEmail] = useState('');
+  const userExpelBottomSheetProps = useBoolean(false);
+
+  const handleOpenExpelModal = (email: string) => {
+    setExpelEmail(email);
+    userExpelBottomSheetProps.on();
+  };
 
   return (
-    <TableContainer component={Paper}>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>유형</TableCell>
-            <TableCell>신고 대상</TableCell>
-            <TableCell>제보자</TableCell>
-            <TableCell>신고 내용</TableCell>
-            <TableCell align="right">동작</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {data.letters.map((letter) => (
-            <TableRow key={letter.id}>
-              <TableCell>{REPORT_TYPE_DICT[letter.reportType]}</TableCell>
-              <TableCell>{letter.reportedEmail}</TableCell>
-              <TableCell>{letter.reporterEmail}</TableCell>
-              <TableCell>{letter.content}</TableCell>
-              <TableCell align="right">
-                <Dropdown
-                  triggerComponent={<MoreHorizontal />}
-                  options={[
-                    {
-                      icon: <Copy width={20} height={20} />,
-                      label: '복사하기',
-                      onClick: () => {
-                        console.log('복사히기 클릭');
-                      },
-                      color: COLORS.gray2,
-                    },
-                    {
-                      icon: <TrashCan width={20} height={20} />,
-                      label: '삭제하기',
-                      onClick: () => {
-                        console.log('삭제하기 클릭');
-                      },
-                      color: COLORS.danger,
-                    },
-                  ]}
-                />
-              </TableCell>
+    <>
+      <UserExpelBottomSheet
+        expelEmail={expelEmail}
+        {...userExpelBottomSheetProps}
+      />
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>유형</TableCell>
+              <TableCell>신고 대상</TableCell>
+              <TableCell>제보자</TableCell>
+              <TableCell>신고 내용</TableCell>
+              <TableCell align="right">동작</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+          </TableHead>
+          <TableBody>
+            {data.letters.map((letter) => (
+              <TableRow key={letter.id}>
+                <TableCell>{REPORT_TYPE_DICT[letter.reportType]}</TableCell>
+                <TableCell>{letter.reportedEmail}</TableCell>
+                <TableCell>{letter.reporterEmail}</TableCell>
+                <TableCell>{letter.content}</TableCell>
+                <TableCell align="right">
+                  <Dropdown
+                    triggerComponent={<MoreHorizontal />}
+                    options={[
+                      {
+                        icon: <TrashCan width={20} height={20} />,
+                        label: '회원 탈퇴',
+                        onClick: () =>
+                          handleOpenExpelModal(letter.reportedEmail),
+                        color: COLORS.danger,
+                      },
+                    ]}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
   );
 };
 

--- a/src/pages/AdminMainPage/tabs/ReportTab.tsx
+++ b/src/pages/AdminMainPage/tabs/ReportTab.tsx
@@ -1,0 +1,7 @@
+import styles from '../style';
+
+const ReportTab = () => {
+  return <div css={styles.tabContent}>ReportTab</div>;
+};
+
+export default ReportTab;

--- a/src/pages/AdminMainPage/tabs/UserTab.tsx
+++ b/src/pages/AdminMainPage/tabs/UserTab.tsx
@@ -12,59 +12,72 @@ import Dropdown from '@/components/Dropdown';
 import { Copy, MoreHorizontal, TrashCan } from '@/assets/icons';
 import COLORS from '@/constants/colors';
 import LoadingSpinner from '@/components/LoadingSpinner';
+import useBoolean from '@/hooks/useBoolean';
 import usePagedUserQuery from '../hooks/usePagedUserQuery';
 import styles from '../style';
+import UserExpelBottomSheet from '../components/UserExpelBottomSheet';
 
 interface SuspensedUserTabProps {
-  email: string;
+  searchEmail: string;
 }
 
-const SuspensedUserTab = ({ email }: SuspensedUserTabProps) => {
-  const { data } = usePagedUserQuery(email);
+const SuspensedUserTab = ({ searchEmail }: SuspensedUserTabProps) => {
+  const { data } = usePagedUserQuery(searchEmail);
+  const [expelEmail, setExpelEmail] = useState('');
+  const userExpelBottomSheetProps = useBoolean(false);
+
+  const handleOpenExpelModal = (email: string) => {
+    setExpelEmail(email);
+    userExpelBottomSheetProps.on();
+  };
 
   return (
-    <TableContainer component={Paper}>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>이메일</TableCell>
-            <TableCell>닉네임</TableCell>
-            <TableCell align="right">동작</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {data.members.map((member) => (
-            <TableRow key={member.id}>
-              <TableCell>{member.email}</TableCell>
-              <TableCell>{member.nickname}</TableCell>
-              <TableCell align="right">
-                <Dropdown
-                  triggerComponent={<MoreHorizontal />}
-                  options={[
-                    {
-                      icon: <Copy width={20} height={20} />,
-                      label: '복사하기',
-                      onClick: () => {
-                        console.log('복사히기 클릭');
-                      },
-                      color: COLORS.gray2,
-                    },
-                    {
-                      icon: <TrashCan width={20} height={20} />,
-                      label: '삭제하기',
-                      onClick: () => {
-                        console.log('삭제하기 클릭');
-                      },
-                      color: COLORS.danger,
-                    },
-                  ]}
-                />
-              </TableCell>
+    <>
+      <UserExpelBottomSheet
+        expelEmail={expelEmail}
+        {...userExpelBottomSheetProps}
+      />
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>이메일</TableCell>
+              <TableCell>닉네임</TableCell>
+              <TableCell align="right">동작</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+          </TableHead>
+          <TableBody>
+            {data.members.map((member) => (
+              <TableRow key={member.id}>
+                <TableCell>{member.email}</TableCell>
+                <TableCell>{member.nickname}</TableCell>
+                <TableCell align="right">
+                  <Dropdown
+                    triggerComponent={<MoreHorizontal />}
+                    options={[
+                      {
+                        icon: <Copy width={20} height={20} />,
+                        label: '편지 보내기',
+                        onClick: () => {
+                          alert('TODO: 편지 보내기는 준비중인 기능이에요');
+                        },
+                        color: COLORS.gray2,
+                      },
+                      {
+                        icon: <TrashCan width={20} height={20} />,
+                        label: '회원 탈퇴',
+                        onClick: () => handleOpenExpelModal(member.email),
+                        color: COLORS.danger,
+                      },
+                    ]}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
   );
 };
 
@@ -81,7 +94,7 @@ const UserTab = () => {
       />
 
       <Suspense fallback={<LoadingSpinner />}>
-        <SuspensedUserTab email={email} />
+        <SuspensedUserTab searchEmail={email} />
       </Suspense>
     </div>
   );

--- a/src/pages/AdminMainPage/tabs/UserTab.tsx
+++ b/src/pages/AdminMainPage/tabs/UserTab.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import Paper from '@mui/material/Paper';
 import {
   Table,
@@ -13,6 +13,7 @@ import { Copy, MoreHorizontal, TrashCan } from '@/assets/icons';
 import COLORS from '@/constants/colors';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import useBoolean from '@/hooks/useBoolean';
+import { debounce } from '@/utils/timerUtils';
 import usePagedUserQuery from '../hooks/usePagedUserQuery';
 import styles from '../style';
 import UserExpelBottomSheet from '../components/UserExpelBottomSheet';
@@ -84,12 +85,19 @@ const SuspensedUserTab = ({ searchEmail }: SuspensedUserTabProps) => {
 const UserTab = () => {
   const [email, setEmail] = useState('');
 
+  const handleDebouncedSearch = useMemo(
+    () =>
+      debounce((e: React.ChangeEvent<HTMLInputElement>) => {
+        setEmail(e.target.value);
+      }, 500),
+    [],
+  );
+
   return (
     <div css={styles.tabContent}>
       <input
         css={styles.input}
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
+        onChange={handleDebouncedSearch}
         placeholder="검색할 이메일을 입력하세요"
       />
 

--- a/src/pages/AdminMainPage/tabs/UserTab.tsx
+++ b/src/pages/AdminMainPage/tabs/UserTab.tsx
@@ -1,0 +1,7 @@
+import styles from '../style';
+
+const UserTab = () => {
+  return <div css={styles.tabContent}>UserTab</div>;
+};
+
+export default UserTab;

--- a/src/pages/AdminMainPage/tabs/UserTab.tsx
+++ b/src/pages/AdminMainPage/tabs/UserTab.tsx
@@ -1,7 +1,90 @@
+import { Suspense, useState } from 'react';
+import Paper from '@mui/material/Paper';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import Dropdown from '@/components/Dropdown';
+import { Copy, MoreHorizontal, TrashCan } from '@/assets/icons';
+import COLORS from '@/constants/colors';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import usePagedUserQuery from '../hooks/usePagedUserQuery';
 import styles from '../style';
 
+interface SuspensedUserTabProps {
+  email: string;
+}
+
+const SuspensedUserTab = ({ email }: SuspensedUserTabProps) => {
+  const { data } = usePagedUserQuery(email);
+
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>이메일</TableCell>
+            <TableCell>닉네임</TableCell>
+            <TableCell align="right">동작</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.members.map((member) => (
+            <TableRow key={member.id}>
+              <TableCell>{member.email}</TableCell>
+              <TableCell>{member.nickname}</TableCell>
+              <TableCell align="right">
+                <Dropdown
+                  triggerComponent={<MoreHorizontal />}
+                  options={[
+                    {
+                      icon: <Copy width={20} height={20} />,
+                      label: '복사하기',
+                      onClick: () => {
+                        console.log('복사히기 클릭');
+                      },
+                      color: COLORS.gray2,
+                    },
+                    {
+                      icon: <TrashCan width={20} height={20} />,
+                      label: '삭제하기',
+                      onClick: () => {
+                        console.log('삭제하기 클릭');
+                      },
+                      color: COLORS.danger,
+                    },
+                  ]}
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
 const UserTab = () => {
-  return <div css={styles.tabContent}>UserTab</div>;
+  const [email, setEmail] = useState('');
+
+  return (
+    <div css={styles.tabContent}>
+      <input
+        css={styles.input}
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="검색할 이메일을 입력하세요"
+      />
+
+      <Suspense fallback={<LoadingSpinner />}>
+        <SuspensedUserTab email={email} />
+      </Suspense>
+    </div>
+  );
 };
 
 export default UserTab;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,6 +13,9 @@ import LetterReplyPage from './pages/LetterReplyPage';
 import LetterStoragePage from './pages/LetterStoragePage';
 import NotFoundPage from './pages/NotFoundPage';
 import { ROUTER_PATHS } from './constants/routerPaths';
+import AdminLayout from './layouts/AdminLayout';
+import AdminMainPage from './pages/AdminMainPage';
+import AdminApp from './AdminApp';
 
 const router = createBrowserRouter([
   {
@@ -68,6 +71,26 @@ const router = createBrowserRouter([
           {
             path: ROUTER_PATHS.LETTER_STORAGE,
             element: <LetterStoragePage />,
+          },
+        ],
+      },
+      {
+        path: '*',
+        element: <NotFoundPage />,
+      },
+    ],
+  },
+  {
+    path: '/',
+    element: <AdminApp />,
+    children: [
+      {
+        path: '/',
+        element: <AdminLayout />,
+        children: [
+          {
+            path: '/admin',
+            element: <AdminMainPage />,
           },
         ],
       },

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -89,7 +89,7 @@ const router = createBrowserRouter([
         element: <AdminLayout />,
         children: [
           {
-            path: '/admin',
+            path: ROUTER_PATHS.ADMIN,
             element: <AdminMainPage />,
           },
         ],

--- a/src/stores/useAdminPageStore.ts
+++ b/src/stores/useAdminPageStore.ts
@@ -1,0 +1,19 @@
+import { createStore, useStore } from 'zustand';
+
+type State = {
+  totalPage: number;
+};
+
+type Action = {
+  setTotalPage: (totalPage: number) => void;
+};
+
+export const adminPageStore = createStore<State & Action>((set) => ({
+  totalPage: 1,
+  setTotalPage: (totalPage) => set({ totalPage }),
+}));
+
+const useAdminPageStore = <T>(selector: (state: State & Action) => T) =>
+  useStore(adminPageStore, selector);
+
+export default useAdminPageStore;

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,0 +1,17 @@
+import { type ReportType } from '@/constants/report';
+import { type Pagination } from './pagination';
+import { type Member } from './member';
+
+export type PagedReportResponse = Pagination & {
+  letters: {
+    id: number;
+    reporterEmail: string;
+    reportedEmail: string;
+    reportType: ReportType;
+    content: string;
+  }[];
+};
+
+export type PagedMemberResponse = Pagination & {
+  members: Omit<Member, 'worryTypes' | 'letterCount'>[];
+};

--- a/src/types/letter.ts
+++ b/src/types/letter.ts
@@ -1,4 +1,5 @@
 import { type Worry } from '@/constants/letters';
+import { type Pagination } from './pagination';
 
 export type Letter = {
   content: string;
@@ -42,10 +43,7 @@ export type Reply = {
   replyImagePath: string | null;
 };
 
-export type Storage = {
-  totalElements: number;
-  totalPage: number;
-  hasNextPage: boolean;
+export type Storage = Pagination & {
   letters: Reply[];
 };
 
@@ -59,9 +57,6 @@ export type SendLetter = {
   sendImagePath: string | null;
 };
 
-export type Send = {
-  totalElements: number;
-  totalPage: number;
-  hasNextPage: boolean;
+export type Send = Pagination & {
   letters: SendLetter[];
 };

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,0 +1,5 @@
+export type Pagination = {
+  totalElements: number;
+  totalPage: number;
+  hasNextPage: boolean;
+};

--- a/src/utils/timerUtils.ts
+++ b/src/utils/timerUtils.ts
@@ -1,0 +1,22 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const debounce = <Callback extends (...args: any[]) => any>(
+  callback: Callback,
+  delay: number = 300,
+) => {
+  let timeout: NodeJS.Timeout;
+
+  return (...args: Parameters<Callback>): ReturnType<Callback> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let result: any;
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(() => {
+      result = callback.apply(this, args);
+    }, delay);
+
+    return result;
+  };
+};


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #258 

## ✅ 작업 사항
- Background에서 컨텐츠 영역의 레이아웃을 분리 (사용자, 관리자 화면 사이즈를 구분하기 위함)
- PaginationBar, Tabs 컴포넌트에 주입해야 할 props 몇 가지 추가
- 관리자 페이지 작성
  - 구현 완료된 부분: 회원 조회, 신고 조회, 이메일로 검색, 회원 탈퇴
  - 추후 구현 필요한 부분: 특정 사용자에게 편지 보내기

## 👩‍💻 공유 포인트 및 논의 사항
급하게 구현해서 코드가 많이 지저분할 것 같네요..
현재 관리자용 API 호출이 안되는 것 같아서 모킹으로만 구현 해 놓았는데, 추후 실제 동작을 확인해야 할 것 같아요.

모킹 환경에서 동작을 확인하기 위해서는 아래 순서로 테스트해볼 수 있어요.
1. 로컬 스토리지에 accessToken을 fresh로 저장
2. /admin 라우팅 경로로 접근

### 사용자 관리 탭
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/321d6b53-cfd3-4350-8513-490b048e2766)

### 신고 관리 탭
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/9038e16b-722c-4cb8-bddc-1afbb4b08ab5)

### 회원 탈퇴 바텀시트
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/a6f796db-98a0-4899-8b1f-49ce2d9c6dd3)

### 회원 검색
키워드 변경 시 해당 이메일을 가지고 API 호출이 발생하도록 작업해 놓았어요.
(500ms의 디바운싱 적용)

![이메일 검색](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/3547b9ae-f6f9-422c-b354-7c7dff312710)
