### PR TITLE
🚑 fix: letterTag가 null일 경우를 대비하여 편지 태그 파싱 로직 수정

### DIFF
--- a/src/pages/LetterReceptionPage/NormalReception/hooks/useLetterWithTags.ts
+++ b/src/pages/LetterReceptionPage/NormalReception/hooks/useLetterWithTags.ts
@@ -12,13 +12,20 @@ const useLetterWithTags = (letterId: number) => {
     ...letterOptions.singleReception(letterId),
   });
 
-  const tagList = data
-    ? [
-        WORRY_DICT[data.worryType as keyof typeof WORRY_DICT],
-        `${data.letterTag?.ageRangeStart}~${data.letterTag?.ageRangeEnd}세`,
-        data.letterTag?.equalGender ? '동성에게' : '모두에게',
-      ]
-    : [];
+  const tagList = [];
+
+  if (data.worryType) {
+    tagList.push(WORRY_DICT[data.worryType]);
+  }
+
+  if (data.letterTag) {
+    tagList.push(
+      `${data.letterTag.ageRangeStart}~${data.letterTag.ageRangeEnd}세`,
+    );
+
+    tagList.push(data.letterTag.equalGender ? '동성에게' : '모두에게');
+  }
+
   const receptionLetter: ReceptionLetterType = { ...data, tagList };
 
   return { receptionLetter };


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #287 

## ✅ 작업 사항
관리자 계정으로 특정 회원에게 편지를 작성할 수 있는데요,
이 경우 응답에서 letterTag 필드가 null로 넘어오기에 태그가 비정상적으로 보이는 현상이 있어요. (빈 문자열, undefined 등)
그래서 이 부분을 수정했어요.

### 편지 상세 요청 GET Response
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/7c89d8e4-dd6c-4c91-9674-7b8671d2cfea)

### 문제되는 화면
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/008c071a-51ed-4cee-96e2-5fddeaa26ad8)

### 수정 완료 화면
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/ada828e5-d6bf-41cc-bad1-6d9ebfa506f4)


## 👩‍💻 공유 포인트 및 논의 사항
letterType을 비교해서 처리하는 방법도 있을 것 같긴 한데.. 태그를 만들어주는 `useLetterWithTags` 의 주 관심사는 `letterTag` 필드라고 생각했어서 letterTag만 가지고 분기 처리하도록 작성했어요. 혹은 더 괜찮은 방법이 있을지도 모르겠네요! 😊