### PR TITLE
🔨 refactor: toast UI 수정

### DIFF
--- a/src/AdminApp.tsx
+++ b/src/AdminApp.tsx
@@ -5,8 +5,8 @@ import Background from '@/components/Background';
 import BackgroundImg from '@/assets/background.png';
 import UnknownErrorBoundary from '@/components/ErrorBoundary/UnknownErrorBoundary';
 import ApiErrorBoundary from '@/components/ErrorBoundary/ApiErrorBoundary';
-import RootApiFallback from './components/ErrorBoundary/fallback/RootApiFallback';
 import RootUnknownFallback from './components/ErrorBoundary/fallback/RootUnknownFallback';
+import RootApiFallback from './components/ErrorBoundary/fallback/RootApiFallback';
 import 'react-toastify/dist/ReactToastify.css';
 
 const AdminApp = () => {
@@ -18,6 +18,7 @@ const AdminApp = () => {
         </ApiErrorBoundary>
       </UnknownErrorBoundary>
       <ToastContainer
+        autoClose={1500}
         css={css({
           margin: '4rem 0 5rem 0',
           padding: '0 1rem',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,8 @@ import BackgroundImg from '@/assets/background.png';
 import Audio from '@/components/Audio';
 import UnknownErrorBoundary from '@/components/ErrorBoundary/UnknownErrorBoundary';
 import ApiErrorBoundary from '@/components/ErrorBoundary/ApiErrorBoundary';
-import RootApiFallback from './components/ErrorBoundary/fallback/RootApiFallback';
 import RootUnknownFallback from './components/ErrorBoundary/fallback/RootUnknownFallback';
+import RootApiFallback from './components/ErrorBoundary/fallback/RootApiFallback';
 import 'react-toastify/dist/ReactToastify.css';
 
 const App = () => {
@@ -22,6 +22,7 @@ const App = () => {
         </UnknownErrorBoundary>
         <Audio src={BackgroundMusic} />
         <ToastContainer
+          autoClose={1500}
           css={css({
             margin: '4rem 0 5rem 0',
             padding: '0 1rem',

--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -9,7 +9,6 @@ export const mutationDefaultErrorHandler = (err: Error) => {
 
   console.error(err);
   toast.error(message, {
-    autoClose: 1500,
     position: 'bottom-center',
   });
 };

--- a/src/components/ReportBottomSheet/index.tsx
+++ b/src/components/ReportBottomSheet/index.tsx
@@ -4,11 +4,11 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useEffect } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
-import ERROR_RESPONSES from '@/constants/errorMessages';
-import { ROUTER_PATHS } from '@/constants/routerPaths';
-import reportAPI from '@/api/report/api';
-import useBoolean from '@/hooks/useBoolean';
 import letterOptions from '@/api/letter/queryOptions';
+import useBoolean from '@/hooks/useBoolean';
+import reportAPI from '@/api/report/api';
+import { ROUTER_PATHS } from '@/constants/routerPaths';
+import ERROR_RESPONSES from '@/constants/errorMessages';
 import BottomSheet from '../BottomSheet';
 import Button from '../Button';
 import LoadingSpinner from '../LoadingSpinner';
@@ -48,7 +48,6 @@ const ReportBottomSheet = ({
         onSuccess: () => {
           toast.success('신고가 접수되었어요.', {
             position: 'bottom-center',
-            autoClose: 1500,
           });
           navigate(ROUTER_PATHS.ROOT);
         },
@@ -72,7 +71,6 @@ const ReportBottomSheet = ({
     if (errors.reportType) {
       toast.warn(errors.reportType.message, {
         position: 'bottom-center',
-        autoClose: 1500,
       });
     }
   }, [errors]);

--- a/src/pages/AdminMainPage/components/LetterWriterModal.tsx
+++ b/src/pages/AdminMainPage/components/LetterWriterModal.tsx
@@ -71,7 +71,6 @@ const LetterWriterModal = ({
         onSuccess: () => {
           toast.success('편지를 보냈어요', {
             position: 'bottom-center',
-            autoClose: 1500,
             hideProgressBar: true,
           });
           off();
@@ -87,7 +86,6 @@ const LetterWriterModal = ({
     if (typeof errorMessages[0] === 'string') {
       toast.warn(errorMessages[0], {
         position: 'bottom-center',
-        autoClose: 1500,
         hideProgressBar: true,
       });
     }

--- a/src/pages/LetterReceptionPage/NormalReception/ReceivedLetter/TossBottomSheet.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/ReceivedLetter/TossBottomSheet.tsx
@@ -35,7 +35,6 @@ const TossBottomSheet = ({
     mutate(letterId, {
       onSuccess: () => {
         toast.success('편지를 다시 바다에 흘러보냈어요', {
-          autoClose: 1500,
           position: 'bottom-center',
         });
         navigate(ROUTER_PATHS.ROOT);

--- a/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReplyBottomSheet.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReplyBottomSheet.tsx
@@ -42,7 +42,6 @@ const ReplyBottomSheet = ({
         onSuccess: () => {
           toast.success('편지를 바다에 띄어보냈어요', {
             position: 'bottom-center',
-            autoClose: 1500,
           });
           navigate(ROUTER_PATHS.ROOT);
         },

--- a/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReplyImage.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReplyImage.tsx
@@ -21,7 +21,7 @@ const ReplyImage = () => {
   const handleDeleteImage = () => {
     off();
     setValue('image', undefined);
-    toast.error('사진이 삭제됐어요', {
+    toast.success('사진이 삭제됐어요', {
       position: 'bottom-center',
     });
   };

--- a/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReplyImage.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReplyImage.tsx
@@ -22,7 +22,6 @@ const ReplyImage = () => {
     off();
     setValue('image', undefined);
     toast.error('사진이 삭제됐어요', {
-      autoClose: 1500,
       position: 'bottom-center',
     });
   };

--- a/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/index.tsx
@@ -1,11 +1,11 @@
 import { useFormContext } from 'react-hook-form';
 import { toast } from 'react-toastify';
 import { useEffect } from 'react';
-import useBoolean from '@/hooks/useBoolean';
-import LetterHeader from '@/components/LetterHeader';
-import LetterLengthDate from '@/components/LetterLengthDate';
-import LetterTextarea from '@/components/LetterTextarea';
 import LetterCard from '@/components/LetterCard';
+import LetterTextarea from '@/components/LetterTextarea';
+import LetterLengthDate from '@/components/LetterLengthDate';
+import LetterHeader from '@/components/LetterHeader';
+import useBoolean from '@/hooks/useBoolean';
 import LetterContent from '../components/LetterContent';
 import useLetterWithTags from '../hooks/useLetterWithTags';
 import { ReplyInputs } from '..';
@@ -39,13 +39,11 @@ const ReplyToLetter = ({ letterId, onPrev }: ReplyToLetterProps) => {
           : errors.replyContent.message;
       toast.warn(message, {
         position: 'bottom-center',
-        autoClose: 1500,
         hideProgressBar: true,
       });
     } else if (errors.image) {
       toast.warn(errors.image.message?.toString(), {
         position: 'bottom-center',
-        autoClose: 1500,
         hideProgressBar: true,
       });
     }

--- a/src/pages/LetterReceptionPage/NormalReception/components/ReceptionPolaroid.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/components/ReceptionPolaroid.tsx
@@ -1,4 +1,3 @@
-import { toast } from 'react-toastify';
 import axios from 'axios';
 import Button from '@/components/Button';
 import PolaroidModal from '@/components/PolaroidModal';
@@ -25,10 +24,6 @@ const ReceptionPolaroid = ({ img, bottomPosition }: ReceptionPolaroidProps) => {
     link.click();
 
     window.URL.revokeObjectURL(url);
-
-    toast.success('사진이 저장됐어요', {
-      position: 'bottom-center',
-    });
   };
 
   return (

--- a/src/pages/LetterReceptionPage/NormalReception/components/ReceptionPolaroid.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/components/ReceptionPolaroid.tsx
@@ -28,7 +28,6 @@ const ReceptionPolaroid = ({ img, bottomPosition }: ReceptionPolaroidProps) => {
 
     toast.success('사진이 저장됐어요', {
       position: 'bottom-center',
-      autoClose: 1500,
     });
   };
 

--- a/src/pages/LetterReplyPage/components/DeleteBottomSheet.tsx
+++ b/src/pages/LetterReplyPage/components/DeleteBottomSheet.tsx
@@ -35,7 +35,6 @@ const DeleteBottomSheet = ({
     mutate(letterId, {
       onSuccess: () => {
         toast.success('편지가 삭제됐어요', {
-          autoClose: 1500,
           position: 'bottom-center',
         });
         navigate(ROUTER_PATHS.ROOT);

--- a/src/pages/LetterReplyPage/components/StorageBottomSheet.tsx
+++ b/src/pages/LetterReplyPage/components/StorageBottomSheet.tsx
@@ -35,7 +35,6 @@ const StorageBottomSheet = ({
     mutate(letterId, {
       onSuccess: () => {
         toast.success('편지를 보관함에 넣었어요', {
-          autoClose: 1500,
           position: 'bottom-center',
         });
         navigate(ROUTER_PATHS.ROOT);

--- a/src/pages/LetterReplyPage/replyLetter/index.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.tsx
@@ -6,8 +6,8 @@ import PolaroidModal from '@/components/PolaroidModal';
 import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
 import { Download } from '@/assets/icons';
-import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
 import LetterContent from '../components/LetterContent';
+import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
 
 interface ReplyLetterProps {
   letterId: number;
@@ -33,7 +33,6 @@ const ReplyLetter = ({ letterId }: ReplyLetterProps) => {
 
     toast.success('사진이 저장됐어요', {
       position: 'bottom-center',
-      autoClose: 1500,
     });
   };
 

--- a/src/pages/LetterReplyPage/replyLetter/index.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.tsx
@@ -1,4 +1,3 @@
-import { toast } from 'react-toastify';
 import axios from 'axios';
 import LetterCard from '@/components/LetterCard';
 import { formatDate } from '@/utils/dateUtils';
@@ -6,8 +5,8 @@ import PolaroidModal from '@/components/PolaroidModal';
 import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
 import { Download } from '@/assets/icons';
-import LetterContent from '../components/LetterContent';
 import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
+import LetterContent from '../components/LetterContent';
 
 interface ReplyLetterProps {
   letterId: number;
@@ -30,10 +29,6 @@ const ReplyLetter = ({ letterId }: ReplyLetterProps) => {
     link.click();
 
     window.URL.revokeObjectURL(url);
-
-    toast.success('사진이 저장됐어요', {
-      position: 'bottom-center',
-    });
   };
 
   return (

--- a/src/pages/LetterStoragePage/components/DeleteBottomSheet.tsx
+++ b/src/pages/LetterStoragePage/components/DeleteBottomSheet.tsx
@@ -40,7 +40,6 @@ const DeleteBottomSheet = ({
   const handleDeleteLetter = async () => {
     const handleSuccess = () => {
       toast.success('편지가 삭제됐어요', {
-        autoClose: 1500,
         position: 'bottom-center',
       });
     };

--- a/src/pages/LetterStoragePage/components/LetterModalHeader.tsx
+++ b/src/pages/LetterStoragePage/components/LetterModalHeader.tsx
@@ -28,14 +28,12 @@ const LetterModalHeader = ({
       .writeText(content)
       .then(() => {
         toast.success('편지가 복사되었어요.', {
-          autoClose: 1500,
           position: 'bottom-center',
         });
       })
       .catch((error) => {
         console.error(error);
         toast.error('편지 복사를 실패했어요', {
-          autoClose: 1500,
           position: 'bottom-center',
         });
       });

--- a/src/pages/LetterWritePage/components/LetterPaper/PolaroidImage.tsx
+++ b/src/pages/LetterWritePage/components/LetterPaper/PolaroidImage.tsx
@@ -17,7 +17,7 @@ const PolaroidImage = () => {
   const handleDeleteImage = () => {
     off();
     setValue('image', undefined);
-    toast.error('사진이 삭제됐어요', {
+    toast.success('사진이 삭제됐어요', {
       position: 'bottom-center',
     });
   };

--- a/src/pages/LetterWritePage/components/LetterPaper/PolaroidImage.tsx
+++ b/src/pages/LetterWritePage/components/LetterPaper/PolaroidImage.tsx
@@ -18,7 +18,6 @@ const PolaroidImage = () => {
     off();
     setValue('image', undefined);
     toast.error('사진이 삭제됐어요', {
-      autoClose: 1500,
       position: 'bottom-center',
     });
   };

--- a/src/pages/LetterWritePage/components/LetterPaper/index.tsx
+++ b/src/pages/LetterWritePage/components/LetterPaper/index.tsx
@@ -4,13 +4,13 @@ import LetterLengthDate from '@/components/LetterLengthDate';
 import LetterCard from '@/components/LetterCard';
 import memberOptions from '@/api/member/queryOptions';
 import LetterHeader from '@/components/LetterHeader';
-import { type WriteInputs } from '../..';
 import {
   LetterReceiverContainer,
   LetterContent,
   PolaroidImage,
   ImageSelect,
 } from '..';
+import { type WriteInputs } from '../..';
 
 const LetterPaper = () => {
   const { watch } = useFormContext<WriteInputs>();

--- a/src/pages/LetterWritePage/components/LetterWriteContainer.tsx
+++ b/src/pages/LetterWritePage/components/LetterWriteContainer.tsx
@@ -34,7 +34,6 @@ const LetterWriteContainer = () => {
   const showToast = (message: string | undefined) => {
     toast.warn(message, {
       position: 'bottom-center',
-      autoClose: 1500,
       hideProgressBar: true,
     });
   };

--- a/src/pages/LetterWritePage/components/WriteBottomSheet.tsx
+++ b/src/pages/LetterWritePage/components/WriteBottomSheet.tsx
@@ -32,7 +32,6 @@ const WriteBottomSheet = ({ value, on, off }: LetterWriteBottomSheetProps) => {
       onSuccess: () => {
         toast.success('편지를 바다에 띄어보냈어요', {
           position: 'bottom-center',
-          autoClose: 1500,
         });
 
         navigate(ROUTER_PATHS.ROOT);


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #289 

## ✅ 작업 사항

1. toast 가 사라지는 시간을 통일시키기 위해 autoClose 를 1500 으로 설정했습니다.

2. 사파리에서 이미지 파일 저장 시, 사진이 저장 되기 전 토스트가 나타나는 현상이 있고,
웬만한 모든 브라우저에서는 파일이 저장 되었다는 것을 브라우저에서 보여주기 때문에 해당 토스트를 제거하였습니다.

[기존]
<img src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/b066f960-0653-402a-a6b5-7c4048565997" width="300" />

3. 이미지 삭제 토스트 success 로 변경하였습니다.

<img width="403" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/f5af8dd6-c1ae-476f-81a7-2d51c4547ee1">


## 👩‍💻 공유 포인트 및 논의 사항

+) 오늘 테스트하다가 발견한 사실인데 카카오 인앱브라우저에서는 이미지를 다운로드 하는 게 안된다고 하네요...
그래서 강제로 외부 브라우저로 이동해야 될 것 같다고 생각이 드네요.

참고 https://devtalk.kakao.com/t/topic/128291
