### PR TITLE
🚑 fix: ErrorBoundary 높이 100svh로 수정

### DIFF
--- a/src/components/ErrorBoundary/fallback/styles.ts
+++ b/src/components/ErrorBoundary/fallback/styles.ts
@@ -9,7 +9,7 @@ const styles = {
     justify-content: center;
     align-items: center;
     width: 100%;
-    height: 100%;
+    height: 100svh;
     background-color: white;
   `,
   image: css`


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #293

## ✅ 작업 사항

ErrorBoundary container 높이를 100% 에서 100svh로 수정했습니다.

[기존]

<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/934c268f-2da2-4f47-a403-f58630d3dbc9">

[변경 후]

<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/66ef7c3a-7e14-45f8-a22d-637aab2d1fd3">

<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/0d5c2ea0-6b5e-44fe-96b4-70ac78cc9025">


## 👩‍💻 공유 포인트 및 논의 사항
