### PR TITLE
🔨 refactor: 흘러온편지 페이지 UI 수정

### DIFF
--- a/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReceivedAccordionLetter.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReceivedAccordionLetter.tsx
@@ -1,10 +1,11 @@
+import { motion } from 'framer-motion';
 import LetterCard from '@/components/LetterCard';
 import LetterAccordion from '@/components/LetterAccordion';
 import useBoolean from '@/hooks/useBoolean';
 import TagList from '@/components/TagList';
 import LetterHeader from '@/components/LetterHeader';
-import ReceptionPolaroid from '../components/ReceptionPolaroid';
 import { ReceptionLetterType } from '../hooks/useLetterWithTags';
+import ReceptionPolaroid from '../components/ReceptionPolaroid';
 
 interface ReceivedAccordionLetterProps {
   receptionLetter: ReceptionLetterType;
@@ -30,10 +31,16 @@ const ReceivedAccordionLetter = ({
         type="send"
       />
       {receptionLetter.sendImagePath !== null && isOpen === true && (
-        <ReceptionPolaroid
-          bottomPosition={1}
-          img={receptionLetter.sendImagePath}
-        />
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 1, ease: 'easeOut' }}
+        >
+          <ReceptionPolaroid
+            bottomPosition={1}
+            img={receptionLetter.sendImagePath}
+          />
+        </motion.div>
       )}
     </LetterCard>
   );

--- a/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReplyButton.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/ReplyButton.tsx
@@ -69,8 +69,8 @@ const style = {
   navbar: css`
     position: fixed;
     bottom: 0;
-    width: 96vw;
-    max-width: 580px;
+    width: calc(100vw - 2rem);
+    max-width: calc(600px - 2rem);
     padding-inline: 0;
   `,
 };

--- a/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/index.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/ReplyToLetter/index.tsx
@@ -1,11 +1,11 @@
 import { useFormContext } from 'react-hook-form';
 import { toast } from 'react-toastify';
 import { useEffect } from 'react';
-import LetterCard from '@/components/LetterCard';
-import LetterTextarea from '@/components/LetterTextarea';
-import LetterLengthDate from '@/components/LetterLengthDate';
-import LetterHeader from '@/components/LetterHeader';
 import useBoolean from '@/hooks/useBoolean';
+import LetterHeader from '@/components/LetterHeader';
+import LetterLengthDate from '@/components/LetterLengthDate';
+import LetterTextarea from '@/components/LetterTextarea';
+import LetterCard from '@/components/LetterCard';
 import LetterContent from '../components/LetterContent';
 import useLetterWithTags from '../hooks/useLetterWithTags';
 import { ReplyInputs } from '..';
@@ -47,7 +47,7 @@ const ReplyToLetter = ({ letterId, onPrev }: ReplyToLetterProps) => {
         hideProgressBar: true,
       });
     }
-  }, [errors]);
+  }, [errors, watch]);
 
   return (
     <LetterContent isBlock={true}>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #295 

1. 버튼 위치

[기존]
<img width="405" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/ad773321-1ddc-4a43-a66c-20fa65c5a412">

[변경 후]
<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/90eb2f38-5b81-43e7-a8bc-d42dc7b52351">
<img width="300" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/2aff5de4-ed0b-4885-977f-acbb5a86d0de">

2. 아코디언 이미지

[기존]

https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/3e1168bd-14c8-45dc-b651-ee9b710b9891



[변경 후]

https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/4895e66d-d9af-4c49-b816-a331c046cb01




## ✅ 작업 사항

## 👩‍💻 공유 포인트 및 논의 사항
