### PR TITLE
✨ feat: 카카오 인앱브라우저에서 외부 브라우저 열기

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,43 @@
         f.parentNode.insertBefore(j, f);
       })(window, document, 'script', 'dataLayer', 'GTM-TQM5BHZD');
     </script>
+    <script type="text/javascript" charset="UTF-8">
+      var inappdeny_exec_vanillajs = (callback) => {
+        if (document.readyState !== 'loading') {
+          callback();
+        } else {
+          document.addEventListener('DOMContentLoaded', callback);
+        }
+      };
+      inappdeny_exec_vanillajs(() => {
+        /* Do things after DOM has fully loaded */
+        function copytoclipboard(val) {
+          var t = document.createElement('textarea');
+          document.body.appendChild(t);
+          t.value = val;
+          t.select();
+          document.execCommand('copy');
+          document.body.removeChild(t);
+        }
+        function inappbrowserout() {
+          copytoclipboard(window.location.href);
+          alert(
+            'URL주소가 복사되었습니다.\n\nSafari가 열리면 주소창을 길게 터치한 뒤, "붙여놓기 및 이동"를 누르면 정상적으로 이용하실 수 있습니다.',
+          );
+          location.href = 'x-web-search://?';
+        }
+
+        var useragt = navigator.userAgent.toLowerCase();
+        var target_url = 'https://oceanletter.site';
+
+        if (useragt.match(/kakaotalk/i)) {
+          //카카오톡 외부브라우저로 호출
+          location.href =
+            'kakaotalk://web/openExternal?url=' +
+            encodeURIComponent(target_url);
+        }
+      });
+    </script>
     <title>내 마음 속 바다</title>
     <meta
       name="description"

--- a/index.html
+++ b/index.html
@@ -47,43 +47,6 @@
         f.parentNode.insertBefore(j, f);
       })(window, document, 'script', 'dataLayer', 'GTM-TQM5BHZD');
     </script>
-    <script type="text/javascript" charset="UTF-8">
-      var inappdeny_exec_vanillajs = (callback) => {
-        if (document.readyState !== 'loading') {
-          callback();
-        } else {
-          document.addEventListener('DOMContentLoaded', callback);
-        }
-      };
-      inappdeny_exec_vanillajs(() => {
-        /* Do things after DOM has fully loaded */
-        function copytoclipboard(val) {
-          var t = document.createElement('textarea');
-          document.body.appendChild(t);
-          t.value = val;
-          t.select();
-          document.execCommand('copy');
-          document.body.removeChild(t);
-        }
-        function inappbrowserout() {
-          copytoclipboard(window.location.href);
-          alert(
-            'URL주소가 복사되었습니다.\n\nSafari가 열리면 주소창을 길게 터치한 뒤, "붙여놓기 및 이동"를 누르면 정상적으로 이용하실 수 있습니다.',
-          );
-          location.href = 'x-web-search://?';
-        }
-
-        var useragt = navigator.userAgent.toLowerCase();
-        var target_url = 'https://oceanletter.site';
-
-        if (useragt.match(/kakaotalk/i)) {
-          //카카오톡 외부브라우저로 호출
-          location.href =
-            'kakaotalk://web/openExternal?url=' +
-            encodeURIComponent(target_url);
-        }
-      });
-    </script>
     <title>내 마음 속 바다</title>
     <meta
       name="description"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -55,7 +55,20 @@ const enableMocking = async () => {
   });
 };
 
-enableMocking().then(() =>
+const redirectIfInAppBrowser = new Promise((resolve, reject) => {
+  const userAgent = navigator.userAgent.toLowerCase();
+  const target_url = window.location.href;
+
+  if (userAgent.match(/kakaotalk/i)) {
+    location.href =
+      'kakaotalk://web/openExternal?url=' + encodeURIComponent(target_url);
+    reject('외부 브라우저로 연결');
+  }
+
+  resolve(true);
+});
+
+Promise.all([enableMocking, redirectIfInAppBrowser]).then(() =>
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #300 

## ✅ 작업 사항

https://burndogfather.com/271 해당 블로그 참고해서 카카오 브라우저만 적용해보았습니다.

아이폰에서는 잘 되네요
상훈님 안드로이드에서도 되는 지 확인 부탁드립니다!


https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/28ffe8c0-7ec7-4898-a0d3-7228e037aef7


## 👩‍💻 공유 포인트 및 논의 사항

```js
else if(useragt.match(/inapp|naver|snapchat|wirtschaftswoche|thunderbird|instagram|everytimeapp|whatsApp|electron|wadiz|aliapp|zumapp|iphone(.*)whale|android(.*)whale|kakaostory|band|twitter|DaumApps|DaumDevice\/mobile|FB_IAB|FB4A|FBAN|FBIOS|FBSS|trill|SamsungBrowser\/[^1]/i))
```

다른 브라우저에서는 어떻게 해야 될 지 고민이네요..