### PR TITLE
✨ feat: 보관한 편지 이미지 다운로드 기능 추가

### DIFF
--- a/src/pages/LetterReceptionPage/NormalReception/components/ReceptionPolaroid.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/components/ReceptionPolaroid.tsx
@@ -1,8 +1,8 @@
-import axios from 'axios';
 import Button from '@/components/Button';
 import PolaroidModal from '@/components/PolaroidModal';
 import IconButton from '@/components/IconButton';
 import { Download } from '@/assets/icons';
+import { imageDownload } from '@/utils/downloadUtils';
 
 interface ReceptionPolaroidProps {
   img: string;
@@ -10,28 +10,12 @@ interface ReceptionPolaroidProps {
 }
 
 const ReceptionPolaroid = ({ img, bottomPosition }: ReceptionPolaroidProps) => {
-  const handleDownload = async () => {
-    const response = await axios.get(img, {
-      responseType: 'blob',
-    });
-
-    const url = window.URL.createObjectURL(new Blob([response.data]));
-
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'image.jpg';
-    document.body.appendChild(link);
-    link.click();
-
-    window.URL.revokeObjectURL(url);
-  };
-
   return (
     <PolaroidModal
       img={img}
       bottomPosition={bottomPosition}
       headerRightContent={
-        <IconButton onClick={handleDownload}>
+        <IconButton onClick={() => imageDownload(img)}>
           <Download color="white" height={20} width={20} />
         </IconButton>
       }

--- a/src/pages/LetterReceptionPage/NormalReception/components/ReceptionPolaroid.tsx
+++ b/src/pages/LetterReceptionPage/NormalReception/components/ReceptionPolaroid.tsx
@@ -2,7 +2,7 @@ import Button from '@/components/Button';
 import PolaroidModal from '@/components/PolaroidModal';
 import IconButton from '@/components/IconButton';
 import { Download } from '@/assets/icons';
-import { imageDownload } from '@/utils/downloadUtils';
+import { downloadImage } from '@/utils/downloadUtils';
 
 interface ReceptionPolaroidProps {
   img: string;
@@ -15,7 +15,7 @@ const ReceptionPolaroid = ({ img, bottomPosition }: ReceptionPolaroidProps) => {
       img={img}
       bottomPosition={bottomPosition}
       headerRightContent={
-        <IconButton onClick={() => imageDownload(img)}>
+        <IconButton onClick={() => downloadImage(img)}>
           <Download color="white" height={20} width={20} />
         </IconButton>
       }

--- a/src/pages/LetterReceptionPage/OnboardingReception/components/PolaroidModal/index.tsx
+++ b/src/pages/LetterReceptionPage/OnboardingReception/components/PolaroidModal/index.tsx
@@ -4,7 +4,7 @@ import IconButton from '@/components/IconButton';
 import Modal from '@/components/Modal';
 import useBoolean from '@/hooks/useBoolean';
 import Button from '@/components/Button';
-import { imageDownload } from '@/utils/downloadUtils';
+import { downloadImage } from '@/utils/downloadUtils';
 import pageStyles from '../../styles';
 import styles from './style';
 
@@ -21,7 +21,7 @@ const PolaroidModal = ({ imagePath, value, off }: PolaroidModalProps) => {
             <CaretLeft css={styles.icon} strokeWidth={2.5} onClick={off} />
           </Header.Left>
           <Header.Right>
-            <IconButton onClick={() => imageDownload(imagePath!)}>
+            <IconButton onClick={() => downloadImage(imagePath!)}>
               <Download css={styles.icon} />
             </IconButton>
           </Header.Right>

--- a/src/pages/LetterReceptionPage/OnboardingReception/components/PolaroidModal/index.tsx
+++ b/src/pages/LetterReceptionPage/OnboardingReception/components/PolaroidModal/index.tsx
@@ -1,10 +1,10 @@
-import axios from 'axios';
 import { CaretLeft, Download } from '@/assets/icons';
 import Header from '@/components/Header';
 import IconButton from '@/components/IconButton';
 import Modal from '@/components/Modal';
 import useBoolean from '@/hooks/useBoolean';
 import Button from '@/components/Button';
+import { imageDownload } from '@/utils/downloadUtils';
 import pageStyles from '../../styles';
 import styles from './style';
 
@@ -13,26 +13,6 @@ interface PolaroidModalProps extends ReturnType<typeof useBoolean> {
 }
 
 const PolaroidModal = ({ imagePath, value, off }: PolaroidModalProps) => {
-  const handleDownload = async () => {
-    if (!imagePath) {
-      return;
-    }
-
-    const response = await axios.get(imagePath, {
-      responseType: 'blob',
-    });
-
-    const url = window.URL.createObjectURL(new Blob([response.data]));
-
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'image.jpg';
-    document.body.appendChild(link);
-    link.click();
-
-    window.URL.revokeObjectURL(url);
-  };
-
   return (
     <Modal isOpen={value} close={off}>
       <div css={styles.container}>
@@ -41,7 +21,7 @@ const PolaroidModal = ({ imagePath, value, off }: PolaroidModalProps) => {
             <CaretLeft css={styles.icon} strokeWidth={2.5} onClick={off} />
           </Header.Left>
           <Header.Right>
-            <IconButton onClick={handleDownload}>
+            <IconButton onClick={() => imageDownload(imagePath!)}>
               <Download css={styles.icon} />
             </IconButton>
           </Header.Right>

--- a/src/pages/LetterReplyPage/replyLetter/index.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.tsx
@@ -4,7 +4,7 @@ import PolaroidModal from '@/components/PolaroidModal';
 import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
 import { Download } from '@/assets/icons';
-import { imageDownload } from '@/utils/downloadUtils';
+import { downloadImage } from '@/utils/downloadUtils';
 import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
 import LetterContent from '../components/LetterContent';
 
@@ -29,7 +29,7 @@ const ReplyLetter = ({ letterId }: ReplyLetterProps) => {
           headerRightContent={
             <IconButton
               id="download-button"
-              onClick={() => imageDownload(replyLetter.replyImagePath!)}
+              onClick={() => downloadImage(replyLetter.replyImagePath!)}
             >
               <Download color="white" height={20} width={20} />
             </IconButton>

--- a/src/pages/LetterReplyPage/replyLetter/index.tsx
+++ b/src/pages/LetterReplyPage/replyLetter/index.tsx
@@ -1,10 +1,10 @@
-import axios from 'axios';
 import LetterCard from '@/components/LetterCard';
 import { formatDate } from '@/utils/dateUtils';
 import PolaroidModal from '@/components/PolaroidModal';
 import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
 import { Download } from '@/assets/icons';
+import { imageDownload } from '@/utils/downloadUtils';
 import useLetterReplyWithTag from '../hooks/useLetterReplyWithTag';
 import LetterContent from '../components/LetterContent';
 
@@ -14,22 +14,6 @@ interface ReplyLetterProps {
 
 const ReplyLetter = ({ letterId }: ReplyLetterProps) => {
   const { replyLetter } = useLetterReplyWithTag(letterId);
-
-  const handleDownload = async () => {
-    const response = await axios.get(replyLetter.replyImagePath!, {
-      responseType: 'blob',
-    });
-
-    const url = window.URL.createObjectURL(new Blob([response.data]));
-
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'image.jpg';
-    document.body.appendChild(link);
-    link.click();
-
-    window.URL.revokeObjectURL(url);
-  };
 
   return (
     <LetterCard isOpen={true}>
@@ -43,7 +27,10 @@ const ReplyLetter = ({ letterId }: ReplyLetterProps) => {
         <PolaroidModal
           img={replyLetter.replyImagePath}
           headerRightContent={
-            <IconButton id="download-button" onClick={handleDownload}>
+            <IconButton
+              id="download-button"
+              onClick={() => imageDownload(replyLetter.replyImagePath!)}
+            >
               <Download color="white" height={20} width={20} />
             </IconButton>
           }

--- a/src/pages/LetterStoragePage/ReplyStorage/ReplyLetterModal.tsx
+++ b/src/pages/LetterStoragePage/ReplyStorage/ReplyLetterModal.tsx
@@ -9,10 +9,9 @@ import TagList from '@/components/TagList';
 import textStyles from '@/styles/textStyles';
 import COLORS from '@/constants/colors';
 import { formatDate } from '@/utils/dateUtils';
-import PolaroidModal from '@/components/PolaroidModal';
-import Button from '@/components/Button';
 import { getTagList } from '../utils/tagUtills';
 import LetterModalHeader from '../components/LetterModalHeader';
+import ReplyPolaroidModal from './ReplyPolaroidModal';
 
 interface ReplyLetterModalProps extends ReturnType<typeof useBoolean> {
   letter: Reply;
@@ -55,11 +54,7 @@ const ReplyLetterModal = ({ value, off, letter }: ReplyLetterModalProps) => {
                 nickname={letter.senderNickname}
               />
               {letter.sendImagePath && (
-                <PolaroidModal img={letter.sendImagePath}>
-                  <Button variant="secondary" size="sm">
-                    닫기
-                  </Button>
-                </PolaroidModal>
+                <ReplyPolaroidModal imagePath={letter.sendImagePath} />
               )}
             </>
           ) : (
@@ -78,11 +73,7 @@ const ReplyLetterModal = ({ value, off, letter }: ReplyLetterModalProps) => {
                 nickname={letter.receiverNickname}
               />
               {letter.replyImagePath && (
-                <PolaroidModal img={letter.replyImagePath}>
-                  <Button variant="secondary" size="sm">
-                    닫기
-                  </Button>
-                </PolaroidModal>
+                <ReplyPolaroidModal imagePath={letter.replyImagePath} />
               )}
             </>
           )}

--- a/src/pages/LetterStoragePage/ReplyStorage/ReplyPolaroidModal.tsx
+++ b/src/pages/LetterStoragePage/ReplyStorage/ReplyPolaroidModal.tsx
@@ -3,7 +3,7 @@ import PolaroidModal from '@/components/PolaroidModal';
 import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
 import { Download } from '@/assets/icons';
-import { imageDownload } from '@/utils/downloadUtils';
+import { downloadImage } from '@/utils/downloadUtils';
 
 interface ReplyPolaroidModalProps {
   imagePath: string;
@@ -16,7 +16,7 @@ const ReplyPolaroidModal = ({ imagePath }: ReplyPolaroidModalProps) => {
       headerRightContent={
         <IconButton
           css={style.download}
-          onClick={() => imageDownload(imagePath)}
+          onClick={() => downloadImage(imagePath)}
         >
           <Download color="white" height={20} width={20} />
         </IconButton>

--- a/src/pages/LetterStoragePage/ReplyStorage/ReplyPolaroidModal.tsx
+++ b/src/pages/LetterStoragePage/ReplyStorage/ReplyPolaroidModal.tsx
@@ -1,37 +1,23 @@
-import axios from 'axios';
 import { css } from '@emotion/react';
 import PolaroidModal from '@/components/PolaroidModal';
 import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
 import { Download } from '@/assets/icons';
+import { imageDownload } from '@/utils/downloadUtils';
 
 interface ReplyPolaroidModalProps {
   imagePath: string;
 }
 
 const ReplyPolaroidModal = ({ imagePath }: ReplyPolaroidModalProps) => {
-  const handleDownload = async () => {
-    console.log('다운로드');
-    const response = await axios.get(imagePath, {
-      responseType: 'blob',
-    });
-
-    const url = window.URL.createObjectURL(new Blob([response.data]));
-
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'image.jpg';
-    document.body.appendChild(link);
-    link.click();
-
-    window.URL.revokeObjectURL(url);
-  };
-
   return (
     <PolaroidModal
       img={imagePath}
       headerRightContent={
-        <IconButton css={style.download} onClick={handleDownload}>
+        <IconButton
+          css={style.download}
+          onClick={() => imageDownload(imagePath)}
+        >
           <Download color="white" height={20} width={20} />
         </IconButton>
       }

--- a/src/pages/LetterStoragePage/ReplyStorage/ReplyPolaroidModal.tsx
+++ b/src/pages/LetterStoragePage/ReplyStorage/ReplyPolaroidModal.tsx
@@ -1,0 +1,52 @@
+import axios from 'axios';
+import { css } from '@emotion/react';
+import PolaroidModal from '@/components/PolaroidModal';
+import Button from '@/components/Button';
+import IconButton from '@/components/IconButton';
+import { Download } from '@/assets/icons';
+
+interface ReplyPolaroidModalProps {
+  imagePath: string;
+}
+
+const ReplyPolaroidModal = ({ imagePath }: ReplyPolaroidModalProps) => {
+  const handleDownload = async () => {
+    console.log('다운로드');
+    const response = await axios.get(imagePath, {
+      responseType: 'blob',
+    });
+
+    const url = window.URL.createObjectURL(new Blob([response.data]));
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'image.jpg';
+    document.body.appendChild(link);
+    link.click();
+
+    window.URL.revokeObjectURL(url);
+  };
+
+  return (
+    <PolaroidModal
+      img={imagePath}
+      headerRightContent={
+        <IconButton css={style.download} onClick={handleDownload}>
+          <Download color="white" height={20} width={20} />
+        </IconButton>
+      }
+    >
+      <Button variant="secondary" size="sm">
+        닫기
+      </Button>
+    </PolaroidModal>
+  );
+};
+
+export default ReplyPolaroidModal;
+
+const style = {
+  download: css`
+    margin-right: 2px;
+  `,
+};

--- a/src/utils/downloadUtils.ts
+++ b/src/utils/downloadUtils.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
  * @param imagePath 이미지 경로
  * @returns
  */
-export const imageDownload = async (imagePath: string) => {
+export const downloadImage = async (imagePath: string) => {
   if (!imagePath) {
     return;
   }

--- a/src/utils/downloadUtils.ts
+++ b/src/utils/downloadUtils.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+/**
+ * 이미지 다운로드
+ * @param imagePath 이미지 경로
+ * @returns
+ */
+export const imageDownload = async (imagePath: string) => {
+  if (!imagePath) {
+    return;
+  }
+
+  const response = await axios.get(imagePath, {
+    responseType: 'blob',
+  });
+
+  const url = window.URL.createObjectURL(new Blob([response.data]));
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'image.jpg';
+  document.body.appendChild(link);
+  link.click();
+
+  window.URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #302 

## ✅ 작업 사항

보관한 편지에 이미지 다운로드 하는 부분이 없어서 추가했습니다.

<img width="529" alt="image" src="https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/98106371/837ee406-c99a-43bc-a8cf-0ccb03963c80">


그리고 이미지 다운로드 하는 부분이 중복되어서 유틸함수로 분리했고 다 잘 동작합니다.

## 👩‍💻 공유 포인트 및 논의 사항
