### PR TITLE
🚑 fix: 프로덕션 환경에서 소스맵 확인할 수 없도록 수정

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,3 @@
+SENTRY_PROJECT= # Sentry Project
+SENTRY_AUTH_TOKEN= # Sentry Auth Token
+SENTRY_ORG= # Sentry Organization

--- a/src/AdminApp.tsx
+++ b/src/AdminApp.tsx
@@ -12,6 +12,13 @@ import 'react-toastify/dist/ReactToastify.css';
 const AdminApp = () => {
   return (
     <Background imageUrl={BackgroundImg}>
+      <button
+        onClick={() => {
+          throw new Error('Sentry 테스트');
+        }}
+      >
+        Sentry 수집 테스트
+      </button>
       <UnknownErrorBoundary FallbackComponent={RootUnknownFallback}>
         <ApiErrorBoundary FallbackComponent={RootApiFallback}>
           <Outlet />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,34 +1,42 @@
 /// <reference types="vitest" />
 import { sentryVitePlugin } from '@sentry/vite-plugin';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    react({
-      jsxImportSource: '@emotion/react',
-    }),
-    sentryVitePlugin({
-      org: 'oceanletter-y1',
-      project: 'oceanletter-react',
-    }),
-  ],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
 
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+  return {
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
 
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./src/setupTests.ts'],
-  },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./src/setupTests.ts'],
+    },
 
-  build: {
-    sourcemap: true,
-  },
+    build: {
+      sourcemap: true,
+    },
+
+    plugins: [
+      react({
+        jsxImportSource: '@emotion/react',
+      }),
+      sentryVitePlugin({
+        org: env.SENTRY_ORG,
+        project: env.SENTRY_PROJECT,
+        authToken: env.SENTRY_AUTH_TOKEN,
+        sourcemaps: {
+          filesToDeleteAfterUpload: ['**/*.js.map'],
+        },
+      }),
+    ],
+  };
 });


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #309 

## ✅ 작업 사항
### 문제점
![image](https://github.com/dnd-side-project/dnd-10th-4-frontend/assets/50488780/37ae5c19-747d-4421-b39c-3f13b8fccf45)

프로덕션 환경에서 Sentry로 캐치한 소스 코드가 minify된 것으로 나타나다 보니, sourcemap을 함께 올리도록 설정했었어요.
그렇다보니 개발자 도구를 열어서 소스 코드를 확인할 수 있는 현상을 발견했는데, [filesToDeleteAfterUpload](https://www.npmjs.com/package/@sentry/vite-plugin#sourcemapsfilestodeleteafterupload) 옵션을 활용해 sourcemap을 Sentry 서버에 전송 완료한 뒤, 제거하는 방식을 적용했어요.

추가로, Sentry 관련 환경 변수는 런타임에서 사용되지 않기 때문에 Vercel 환경 변수로만 등록해 놓은 상황이에요. 이 부분은 git에 올리지 않고 예시 파일만 작성해두었어요.

(playground 레포에서 테스트 했을 땐 이상은 없었는데, 현재 프로젝트에도 직접 배포해봐야 정상 작동을 확인할 수 있다 보니, 먼저 머지해놓겠습니다!)

## 👩‍💻 공유 포인트 및 논의 사항
